### PR TITLE
Fix python bindings compilation after rebranding

### DIFF
--- a/src/plugins/PluginManager.cpp
+++ b/src/plugins/PluginManager.cpp
@@ -3,7 +3,7 @@
 
 #ifdef IAITO_ENABLE_PYTHON_BINDINGS
 #include <Python.h>
-#include <cutterbindings_python.h>
+#include <iaitobindings_python.h>
 #include "PythonManager.h"
 #endif
 
@@ -220,7 +220,7 @@ IaitoPlugin *PluginManager::loadPythonPlugin(const char *moduleName)
         return nullptr;
     }
 
-    PythonToCppFunc pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkIaitoBindingsTypes[SBK_CUTTERPLUGIN_IDX]), pluginObject);
+    PythonToCppFunc pythonToCpp = Shiboken::Conversions::isPythonToCppPointerConvertible(reinterpret_cast<SbkObjectType *>(SbkIaitoBindingsTypes[SBK_IAITOPLUGIN_IDX]), pluginObject);
     if (!pythonToCpp) {
         qWarning() << "Plugin's create_cutter_plugin() function did not return an instance of IaitoPlugin:" << QString(moduleName);
         return nullptr;


### PR DESCRIPTION
<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

The rebranding to iaito broke some things, like the python bindings. This fixes the header include and the IDX constant.

**Test plan (required)**

```
  cmake -B build \
    -DCMAKE_INSTALL_PREFIX=/usr \
    -DCMAKE_BUILD_TYPE=None \
    -DIAITO_ENABLE_PYTHON=ON \
    -DIAITO_ENABLE_PYTHON_BINDINGS=ON \
    -DIAITO_USE_BUNDLED_RADARE2=OFF \
    -DIAITO_USE_ADDITIONAL_RADARE2_PATHS=OFF \
    -DIAITO_ENABLE_CRASH_REPORTS=OFF \
    -DIAITO_ENABLE_GRAPHVIZ=ON \
    -Wno-dev \
    -G Ninja
  ninja -C build
```