### PR TITLE
workaround missing include in kf5-syntax-highlighting-devel

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,6 +268,8 @@ endif()
 if(TARGET KF5::SyntaxHighlighting)
     target_link_libraries(iaito PRIVATE KF5::SyntaxHighlighting)
     target_compile_definitions(iaito PRIVATE IAITO_ENABLE_KSYNTAXHIGHLIGHTING)
+    # in the kf5-syntax-highlighting-devel 5.91.0 the cmake files dropped advertising of the /usr/include/KF5 include directory
+    include_directories(AFTER /usr/include/KF5)
 endif()
 
 if (IAITO_APPIMAGE_BUILD)


### PR DESCRIPTION
In the kf5-syntax-highlighting-devel 5.91.0 the cmake files dropped advertising of the /usr/include/KF5 include directory.
As Iaito is referencing those with <KSyntaxHighlighting/repository.h> relative to /usr/include/KF5 we need to add this include directory in order to be able to compile successfully.

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)



**Closing issues**
<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
closes #70

