### PR TITLE
Fix KSyntaxHighlighting includes.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -268,8 +268,6 @@ endif()
 if(TARGET KF5::SyntaxHighlighting)
     target_link_libraries(iaito PRIVATE KF5::SyntaxHighlighting)
     target_compile_definitions(iaito PRIVATE IAITO_ENABLE_KSYNTAXHIGHLIGHTING)
-    # in the kf5-syntax-highlighting-devel 5.91.0 the cmake files dropped advertising of the /usr/include/KF5 include directory
-    include_directories(AFTER /usr/include/KF5)
 endif()
 
 if (IAITO_APPIMAGE_BUILD)

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -7,9 +7,9 @@
 #include <QApplication>
 
 #ifdef IAITO_ENABLE_KSYNTAXHIGHLIGHTING
-#include <KSyntaxHighlighting/repository.h>
-#include <KSyntaxHighlighting/theme.h>
-#include <KSyntaxHighlighting/definition.h>
+#include <KSyntaxHighlighting/Repository>
+#include <KSyntaxHighlighting/Theme>
+#include <KSyntaxHighlighting/Definition>
 #endif
 
 #include "common/ColorThemeWorker.h"

--- a/src/common/SyntaxHighlighter.cpp
+++ b/src/common/SyntaxHighlighter.cpp
@@ -5,7 +5,7 @@
 
 #include "Configuration.h"
 
-#include <KSyntaxHighlighting/theme.h>
+#include <KSyntaxHighlighting/Theme>
 
 SyntaxHighlighter::SyntaxHighlighter(QTextDocument *document) : KSyntaxHighlighting::SyntaxHighlighter(document)
 {

--- a/src/common/SyntaxHighlighter.h
+++ b/src/common/SyntaxHighlighter.h
@@ -10,7 +10,7 @@
 
 #ifdef IAITO_ENABLE_KSYNTAXHIGHLIGHTING
 
-#include <KSyntaxHighlighting/syntaxhighlighter.h>
+#include <KSyntaxHighlighting/SyntaxHighlighter>
 
 class SyntaxHighlighter : public KSyntaxHighlighting::SyntaxHighlighter
 {


### PR DESCRIPTION
Mixing Camelcase and standard include wasn't the intended way.
This was fixed in syntax-highlighting 5.91.

Amends 24a2eba2

<!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [x] I've read the [guidelines for contributing](https://cutter.re/docs/contributing/code/getting-started.html) to this repository
- [x] I made sure to follow the project's [coding style](https://cutter.re/docs/contributing/code/development-guidelines.html)
- [x] I've updated the [documentation](https://cutter.re/docs/user-docs.html) with the relevant information (if needed)


**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

**Test plan (required)**

<!-- What steps should the reviewer take to test your pull request? Demonstrate that the code is solid. Example: The exact actions you made and their outcome. Add screenshots/videos if the pull request changes UI. This is your time to re-check that everything works and that you covered all the edge cases -->


<!-- **Code formatting**
Make sure you ran astyle on your code before making the PR. Check our contribution guidelines here: https://cutter.re/docs/code.html -->

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if such). -->
