### PR TITLE
remove duplicate StartupNotify=true

### DIFF
--- a/src/org.radare.iaito.desktop
+++ b/src/org.radare.iaito.desktop
@@ -5,7 +5,6 @@ Exec=iaito
 Icon=org.radare.iaito
 
 Categories=Qt;Development;Debugger;Viewer;ComputerScience;DataVisualization;Emulator;FileTools;Security;
-StartupNotify=true
 GenericName=GUI to Radare2 reverse engineering platform
 Comment=It can serve as disassembler, debugger, hex viewer / editor and decompiler to several binary architectures and file formats
 Keywords=radare2;radare;r2;iaito;gdb;disassembler;debugger;c;c++;assembler;decompiler;binary;asm;arm;exe;viewer;


### PR DESCRIPTION
Having duplicate StartupNotify is making the desktop file invalid on some platforms and is not passing the sanity check for the Fedora package build https://kojipkgs.fedoraproject.org//work/tasks/9327/92669327/build.log

```
+ appstream-util validate-relax --nonet /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64/usr/share/metainfo/org.radare.iaito.appdata.xml /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64/usr/share/metainfo/org.radare.iaito.appdata.xml: OK
+ desktop-file-validate /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64//usr/share/applications/org.radare.iaito.desktop /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64//usr/share/applications/org.radare.iaito.desktop: hint: value item "Viewer" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Graphics, or Office /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64//usr/share/applications/org.radare.iaito.desktop: hint: value item "ComputerScience" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Education, or Science /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64//usr/share/applications/org.radare.iaito.desktop: hint: value item "DataVisualization" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Education, or Science /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64//usr/share/applications/org.radare.iaito.desktop: hint: value item "Emulator" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: System, or Game /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64//usr/share/applications/org.radare.iaito.desktop: hint: value item "FileTools" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Utility, or System /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64//usr/share/applications/org.radare.iaito.desktop: hint: value item "Security" in key "Categories" in group "Desktop Entry" can be extended with another category among the following categories: Settings, or System /builddir/build/BUILDROOT/iaito-5.7.6-1.fc38.x86_64//usr/share/applications/org.radare.iaito.desktop: error: file contains multiple keys named "StartupNotify" in group "Desktop Entry" error: Bad exit status from /var/tmp/rpm-tmp.iTnWFV (%check) RPM build errors:
    Bad exit status from /var/tmp/rpm-tmp.iTnWFV (%check)
Child return code was: 1
EXCEPTION: [Error()]

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**
```
<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
