### PR TITLE
Fix release CI failing on macOS artifact upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,7 +285,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/iaito-x64.dmg/iaito/iaito_x64.dmg
+          asset_path: dist/artifacts/iaito-x64.dmg/iaito.dmg
           asset_name: iaito_${{ steps.version.outputs.string }}_x64.dmg
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload Windows QtDeploy asset
@@ -295,7 +295,7 @@ jobs:
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: dist/artifacts/iaito.zip/iaito.zip
-          asset_name: iaito-${{ steps.version.outputs.string }}-macos.zip
+          asset_name: iaito-${{ steps.version.outputs.string }}-w64.zip
           asset_content_type: application/zip
       - name: Upload Windows executable
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

Changed path where CI was looking for macOS artifact, should now find them during a release. Also, fixed the Windows artifact having 'macos' in it's name.
