### PR TITLE
Fixes dependencies for Debian packages generation

### DIFF
--- a/dist/debian/CONFIG
+++ b/dist/debian/CONFIG
@@ -1,8 +1,7 @@
 NAME=iaito
 SECTION=editors
 PRIORITY=optional
-PACKAGES="radare2 libqt5core5a libqt5gui5 libqt5widgets5 libqt5network5 libqt5svg5"
-DEPENDS=$(../getpkgversions.sh $PACKAGES)
+DEPENDS=$(shell ../getpkgversions.sh radare2 libqt5core5a libqt5gui5 libqt5widgets5 libqt5network5 libqt5svg5)
 MAINTAINER=pancake <pancake@nopcode.org>
 ARCH?=amd64
 VERSION=$(shell ../../../configure -qV)

--- a/dist/debian/iaito/Makefile
+++ b/dist/debian/iaito/Makefile
@@ -1,6 +1,5 @@
 PACKAGE_DIR=$(shell pwd)
 include ./CONFIG
-DEPENDS=
 
 SUDO=fakeroot
 SUDO=sudo


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #142
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

* The DEPENDS variable was being nullified in the Makefile.
* The proper syntax for executing a shell script from a makefile is now being used.