### PR TITLE
Issue #148: Make RelocsWidget constructor like ExportsWidget

### DIFF
--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -163,12 +163,13 @@ bool RelocsProxyModel::lessThan(const QModelIndex &left, const QModelIndex &righ
 }
 
 RelocsWidget::RelocsWidget(MainWindow *main) :
-    ListDockWidget(main),
-    relocsModel(new RelocsModel(&relocs, this)),
-    relocsProxyModel(new RelocsProxyModel(relocsModel, this))
+    ListDockWidget(main)
 {
     setWindowTitle(tr("Relocs"));
     setObjectName("RelocsWidget");
+
+    relocsModel = new RelocsModel(&relocs, this);
+    relocsProxyModel = new RelocsProxyModel(relocsModel, this);
 
     setModels(relocsProxyModel);
     ui->treeView->sortByColumn(RelocsModel::NameColumn, Qt::AscendingOrder);


### PR DESCRIPTION
For some subtleties of C++ constructors that are lost on me, making the RelocsWidget constructor look the same as the ExportsWidget constructor dodges a segfault at startup. I've tested this only on x86_64 Ubuntu 22.04.3

**Checklist**

- [ ] Closing issues: #issue
- [ X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
