### PR TITLE
Fix file dialog type, which sometimes breaks build [#152]

### DIFF
--- a/src/core/Iaito.h
+++ b/src/core/Iaito.h
@@ -34,7 +34,7 @@ class R2TaskDialog;
 #if __APPLE__ && QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
 #define QFILEDIALOG_FLAGS QFileDialog::DontUseNativeDialog
 #else
-#define QFILEDIALOG_FLAGS 0
+#define QFILEDIALOG_FLAGS ((QFileDialog::Option) 0)
 #endif
 #define Core() (IaitoCore::instance())
 


### PR DESCRIPTION
**Checklist**

- [x] Closing issues: #152
- [ x] Mark this if you consider it ready to merge (if it isn't can't I just make a draft pr instead of having this checkbox here?)
- [ ] I've added tests (optional)
- [ ] I wrote some documentation
On some configurations, the compiler wants a type cast because it can't automatically cast 0 to one of the enum members