### PR TITLE
Ticket#174/Keep the logic thru skipOptionsDialog

### DIFF
--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -534,18 +534,20 @@ void MainWindow::openCurrentCore(InitialOptions &options, bool skipOptionsDialog
 
 void MainWindow::openNewFile(InitialOptions &options, bool skipOptionsDialog)
 {
-    setFilename(options.filename);
+    if (!skipOptionsDialog) {
+        setFilename(options.filename);
 
-    /* Prompt to load filename.r2 script */
-    if (options.script.isEmpty()) {
-        QString script = QString("%1.r2").arg(this->filename);
-        if (r_file_exists(script.toStdString().data())) {
-            QMessageBox mb;
-            mb.setWindowTitle(tr("Script loading"));
-            mb.setText(tr("Do you want to load the '%1' script?").arg(script));
-            mb.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
-            if (mb.exec() == QMessageBox::Yes) {
-                options.script = script;
+        /* Prompt to load filename.r2 script */
+        if (options.script.isEmpty()) {
+            QString script = QString("%1.r2").arg(this->filename);
+            if (r_file_exists(script.toStdString().data())) {
+                QMessageBox mb;
+                mb.setWindowTitle(tr("Script loading"));
+                mb.setText(tr("Do you want to load the '%1' script?").arg(script));
+                mb.setStandardButtons(QMessageBox::Yes | QMessageBox::No);
+                if (mb.exec() == QMessageBox::Yes) {
+                    options.script = script;
+                }
             }
         }
     }
@@ -602,7 +604,7 @@ void MainWindow::displayInitialOptionsDialog(const InitialOptions &options, bool
     o->loadOptions(options);
 
     if (skipOptionsDialog) {
-        o->setupAndStartAnalysis();
+        o->setupAndStartAnalysis(skipOptionsDialog);
     } else {
         o->show();
     }

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -261,13 +261,15 @@ QList<CommandDescription> InitialOptionsDialog::getSelectedAdvancedAnalCmds() co
     return advanced;
 }
 
-void InitialOptionsDialog::setupAndStartAnalysis(/*int level, QList<QString> advanced*/)
+void InitialOptionsDialog::setupAndStartAnalysis(bool skipFileLoading)
 {
     InitialOptions options;
 
-    options.filename = main->getFilename();
-    if (!options.filename.isEmpty()) {
-        main->setWindowTitle("iaito – " + options.filename);
+    if (!skipFileLoading) {
+        options.filename = main->getFilename();
+        if (!options.filename.isEmpty()) {
+            main->setWindowTitle("iaito – " + options.filename);
+        }
     }
     options.shellcode = this->shellcode;
 
@@ -355,14 +357,14 @@ void InitialOptionsDialog::setupAndStartAnalysis(/*int level, QList<QString> adv
 
     // Demangle (must be before file Core()->loadFile)
     Core()->setConfig("bin.demangle", options.demangle);
-    if (options.filename.endsWith("://") || options.filename == "") {
+    if ((options.filename.endsWith("://") || options.filename == "") && !skipFileLoading) {
         QMessageBox::warning(this, tr("Error"), tr("Please select a file"));
         return;
     }
     // Do not reload the file if already loaded
     // QJsonArray openedFiles = Core()->getOpenedFiles();
     // if (true)  { // !openedFiles.size() && options.filename.length()) {
-    if (options.filename.length()) {
+    if (options.filename.length() && !skipFileLoading) {
         bool fileLoaded = Core()->loadFile(options.filename,
                                            options.binLoadAddr,
                                            options.mapAddr,

--- a/src/dialogs/InitialOptionsDialog.h
+++ b/src/dialogs/InitialOptionsDialog.h
@@ -20,7 +20,7 @@ public:
     explicit InitialOptionsDialog(MainWindow *main);
     ~InitialOptionsDialog();
 
-    void setupAndStartAnalysis(/*int level, QList<QString> advanced*/);
+    void setupAndStartAnalysis(bool skipFileLoading = false);
 
 private slots:
     void on_okButton_clicked();

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -369,11 +369,10 @@ void NewFileDialog::loadFile(const QString &filename)
         msgBox.exec();
         return;
     }
-    if (filename == "" || filename.endsWith("://")) {
+    if ((filename == "" || filename.endsWith("://")) && !ui->checkBox_FilelessOpen->isChecked()) {
         QMessageBox::warning(this, tr("Error"), tr("Select a file before clicking this button"));
         return;
     }
-
 
     // Add file to recent file list
     QSettings settings;


### PR DESCRIPTION
This PR is the fix for the https://github.com/radareorg/iaito/issues/174

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

The approach followed here is to keep propagating the `checkBox_FilelessOpen` value to `setupAndStartAnalysis` (passing thru `openNewFile` and `displayInitialOptionsDialog`). The idea is to avoid setting any file name nor loading it while maintaining as much as existing logic and program flow as possible. I think a cleaner approach can be done ([in a following PR](https://github.com/radareorg/iaito/pull/177)) checking it earlier and jump to `finalizeOpen`. [More about this on this other PR](https://github.com/radareorg/iaito/pull/177), merge only one of them and close the other.

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
