### PR TITLE
Ticket#174/Skip opening a file, clean version

### DIFF
--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -361,19 +361,26 @@ void NewFileDialog::fillIOPluginsList()
 
 void NewFileDialog::loadFile(const QString &filename)
 {
+    bool skipOpeningFile = ui->checkBox_FilelessOpen->isChecked();
     const QString &nativeFn = QDir::toNativeSeparators(filename);
     if (ui->ioPlugin->currentIndex() == 0 && !Core()->tryFile(nativeFn, false)
-            && !ui->checkBox_FilelessOpen->isChecked()) {
+            && !skipOpeningFile) {
         QMessageBox msgBox(this);
         msgBox.setText(tr("Select a new program or a previous one before continuing."));
         msgBox.exec();
         return;
     }
-    if (filename == "" || filename.endsWith("://")) {
+    if ((filename == "" || filename.endsWith("://")) && !skipOpeningFile) {
         QMessageBox::warning(this, tr("Error"), tr("Select a file before clicking this button"));
         return;
     }
 
+    if (skipOpeningFile) {
+        /* If we don't want to open a file just skip setting options and move to finalize */
+        main->finalizeOpen();
+        close();
+        return;
+    }
 
     // Add file to recent file list
     QSettings settings;
@@ -393,7 +400,7 @@ void NewFileDialog::loadFile(const QString &filename)
     ioFile += nativeFn;
     InitialOptions options;
     options.filename = ioFile;
-    main->openNewFile(options, ui->checkBox_FilelessOpen->isChecked());
+    main->openNewFile(options);
 
     close();
 }


### PR DESCRIPTION
Cleaner version of the PR in https://github.com/radareorg/iaito/pull/176 
It's still a fix for the ticket https://github.com/radareorg/iaito/issues/174

I made two versions because for me this is the good one but, it will depend on the opinion on how of the existing flow needs to be maintained.

Skip opening a file (via the `checkBox_FilelessOpen`), clean version with only changes inside `NewFileDialog::loadFile`, without calling `openNewFile`, `displayInitialOptionsDialog` and `setupAndStartAnalysis`. Skipping directly to `finalizeOpen`

**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
