### PR TITLE
disable and hide widgets when we are not going to open a file

### DIFF
--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -64,6 +64,7 @@ NewFileDialog::NewFileDialog(MainWindow *main) :
     ui->projectsListWidget->addAction(ui->actionRemove_project);
     ui->logoSvgWidget->load(Config()->getLogoFile());
 
+    setSpacerEnabled(ui->verticalSpacer, false);
     // radare2 does not seem to save this config so here we load this manually
     Core()->setConfig("dir.projects", Config()->getDirProjects());
 
@@ -85,6 +86,26 @@ NewFileDialog::~NewFileDialog() {}
 void NewFileDialog::on_loadFileButton_clicked()
 {
     loadFile(ui->newFileEdit->text());
+}
+
+void NewFileDialog::on_checkBox_FilelessOpen_clicked()
+{
+    /*
+     * When we're not opening any file, we must hide all file-related widgets
+     */
+    bool disable_and_hide = !ui->checkBox_FilelessOpen->isChecked();
+    setSpacerEnabled(ui->verticalSpacer, !disable_and_hide);
+    QVector<QWidget*> widgets_to_hide = {
+        ui->recentsListWidget,
+        ui->ioPlugin,
+        ui->newFileEdit,
+        ui->newFileLabel,
+        ui->ioLabel,
+        ui->selectFileButton
+    };
+    for (QWidget* widget : widgets_to_hide) {
+        setDisableAndHideWidget(widget, disable_and_hide);
+    }
 }
 
 void NewFileDialog::on_selectFileButton_clicked()
@@ -421,6 +442,21 @@ void NewFileDialog::loadShellcode(const QString &shellcode, const int size)
     options.shellcode = shellcode;
     main->openNewFile(options);
     close();
+}
+
+void NewFileDialog::setDisableAndHideWidget(QWidget *w, bool disable_and_hide)
+{
+    w->setDisabled(disable_and_hide);
+    w->setVisible(disable_and_hide);
+}
+
+void NewFileDialog::setSpacerEnabled(QSpacerItem *s, bool enabled, int w, int h)
+{
+    if (enabled) {
+        s->changeSize(w, h, QSizePolicy::Expanding, QSizePolicy::Expanding);
+    } else {
+        s->changeSize(0, 0, QSizePolicy::Fixed, QSizePolicy::Fixed);
+    }
 }
 
 void NewFileDialog::on_tabWidget_currentChanged(int index)

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -3,6 +3,7 @@
 
 #include <QDialog>
 #include <QListWidgetItem>
+#include <QSpacerItem>
 #include <memory>
 
 namespace Ui {
@@ -21,6 +22,7 @@ public:
 
 private slots:
     void on_loadFileButton_clicked();
+    void on_checkBox_FilelessOpen_clicked();
     void on_selectFileButton_clicked();
 
     void on_selectProjectsDirButton_clicked();
@@ -64,6 +66,9 @@ private:
     void loadFile(const QString &filename);
     void loadProject(const QString &project);
     void loadShellcode(const QString &shellcode, const int size);
+
+    void setDisableAndHideWidget(QWidget *w, bool disable_and_hide = true);
+    void setSpacerEnabled(QSpacerItem *s, bool enabled, int w = 10, int h = 10);
 
     static const int MaxRecentFiles = 5;
 };

--- a/src/dialogs/NewFileDialog.ui
+++ b/src/dialogs/NewFileDialog.ui
@@ -34,7 +34,7 @@
      <property name="bottomMargin">
       <number>2</number>
      </property>
-     <item alignment="Qt::AlignHCenter">
+     <item alignment="Qt::AlignmentFlag::AlignHCenter">
       <widget class="QSvgWidget" name="logoSvgWidget" native="true">
        <property name="minimumSize">
         <size>
@@ -63,7 +63,7 @@
      <item>
       <spacer name="horizontalSpacer_4">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -86,7 +86,7 @@
      <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -124,10 +124,10 @@
         </size>
        </property>
        <property name="frameShape">
-        <enum>QFrame::NoFrame</enum>
+        <enum>QFrame::Shape::NoFrame</enum>
        </property>
        <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
+        <enum>QFrame::Shadow::Plain</enum>
        </property>
        <layout class="QVBoxLayout" name="verticalLayout_2">
         <property name="leftMargin">
@@ -155,7 +155,7 @@
             <item>
              <layout class="QGridLayout" name="gridLayout">
               <property name="sizeConstraint">
-               <enum>QLayout::SetDefaultConstraint</enum>
+               <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
               </property>
               <property name="horizontalSpacing">
                <number>5</number>
@@ -222,13 +222,13 @@
                </font>
               </property>
               <property name="contextMenuPolicy">
-               <enum>Qt::ActionsContextMenu</enum>
+               <enum>Qt::ContextMenuPolicy::ActionsContextMenu</enum>
               </property>
               <property name="frameShape">
-               <enum>QFrame::NoFrame</enum>
+               <enum>QFrame::Shape::NoFrame</enum>
               </property>
               <property name="frameShadow">
-               <enum>QFrame::Plain</enum>
+               <enum>QFrame::Shadow::Plain</enum>
               </property>
               <property name="lineWidth">
                <number>0</number>
@@ -240,16 +240,16 @@
                </size>
               </property>
               <property name="verticalScrollMode">
-               <enum>QAbstractItemView::ScrollPerPixel</enum>
+               <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
               </property>
               <property name="resizeMode">
-               <enum>QListView::Adjust</enum>
+               <enum>QListView::ResizeMode::Adjust</enum>
               </property>
               <property name="spacing">
                <number>5</number>
               </property>
               <property name="viewMode">
-               <enum>QListView::ListMode</enum>
+               <enum>QListView::ViewMode::ListMode</enum>
               </property>
               <property name="uniformItemSizes">
                <bool>false</bool>
@@ -266,11 +266,24 @@
              </widget>
             </item>
             <item>
+             <spacer name="verticalSpacer">
+              <property name="orientation">
+               <enum>Qt::Orientation::Vertical</enum>
+              </property>
+              <property name="sizeHint" stdset="0">
+               <size>
+                <width>20</width>
+                <height>40</height>
+               </size>
+              </property>
+             </spacer>
+            </item>
+            <item>
              <layout class="QHBoxLayout" name="horizontalLayout">
               <item>
                <spacer name="horizontalSpacer_2">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -334,7 +347,7 @@
               <item>
                <spacer name="shellcodeSpacer">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>
@@ -363,7 +376,7 @@
             <item>
              <layout class="QGridLayout" name="gridLayout_2">
               <property name="sizeConstraint">
-               <enum>QLayout::SetDefaultConstraint</enum>
+               <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
               </property>
               <property name="horizontalSpacing">
                <number>5</number>
@@ -420,13 +433,13 @@
                </font>
               </property>
               <property name="contextMenuPolicy">
-               <enum>Qt::ActionsContextMenu</enum>
+               <enum>Qt::ContextMenuPolicy::ActionsContextMenu</enum>
               </property>
               <property name="frameShape">
-               <enum>QFrame::NoFrame</enum>
+               <enum>QFrame::Shape::NoFrame</enum>
               </property>
               <property name="frameShadow">
-               <enum>QFrame::Plain</enum>
+               <enum>QFrame::Shadow::Plain</enum>
               </property>
               <property name="lineWidth">
                <number>0</number>
@@ -438,16 +451,16 @@
                </size>
               </property>
               <property name="verticalScrollMode">
-               <enum>QAbstractItemView::ScrollPerPixel</enum>
+               <enum>QAbstractItemView::ScrollMode::ScrollPerPixel</enum>
               </property>
               <property name="resizeMode">
-               <enum>QListView::Adjust</enum>
+               <enum>QListView::ResizeMode::Adjust</enum>
               </property>
               <property name="spacing">
                <number>5</number>
               </property>
               <property name="viewMode">
-               <enum>QListView::ListMode</enum>
+               <enum>QListView::ViewMode::ListMode</enum>
               </property>
               <property name="uniformItemSizes">
                <bool>false</bool>
@@ -465,7 +478,7 @@
               <item>
                <spacer name="horizontalSpacer_3">
                 <property name="orientation">
-                 <enum>Qt::Horizontal</enum>
+                 <enum>Qt::Orientation::Horizontal</enum>
                 </property>
                 <property name="sizeHint" stdset="0">
                  <size>


### PR DESCRIPTION
Disable and hide file related widgets when we are not going to open a file, while maintaining the dialog geometry

from issue: https://github.com/radareorg/iaito/issues/179

![image](https://github.com/user-attachments/assets/3232adfa-5dd6-40ce-84b0-fbdedcc6c163)
![image](https://github.com/user-attachments/assets/8c2a6dac-81f8-44e7-867c-fe851681c450)


**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
