### PR TITLE
185/remove about button and convert the svg logo to a clickable widget

### DIFF
--- a/src/Iaito.pro
+++ b/src/Iaito.pro
@@ -469,6 +469,7 @@ HEADERS  += \
     core/IaitoDescriptions.h \
     dialogs/EditStringDialog.h \
     dialogs/WriteCommandsDialogs.h \
+    widgets/ClickableSvgWidget.h \
     widgets/DisassemblerGraphView.h \
     widgets/OverviewView.h \
     common/RichTextPainter.h \

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -72,6 +72,9 @@ NewFileDialog::NewFileDialog(MainWindow *main) :
     fillIOPluginsList();
     fillProjectsList();
 
+    connect(ui->logoSvgWidget, SIGNAL(clicked()), this, SLOT(on_aboutButton_clicked()));
+    ui->logoSvgWidget->setToolTip(tr("About Iaito"));
+
     // Set last clicked tab
     ui->tabWidget->setCurrentIndex(Config()->getNewFileLastClicked());
 

--- a/src/dialogs/NewFileDialog.h
+++ b/src/dialogs/NewFileDialog.h
@@ -5,6 +5,7 @@
 #include <QListWidgetItem>
 #include <QSpacerItem>
 #include <memory>
+#include "../widgets/ClickableSvgWidget.h"
 
 namespace Ui {
 class NewFileDialog;

--- a/src/dialogs/NewFileDialog.ui
+++ b/src/dialogs/NewFileDialog.ui
@@ -35,7 +35,7 @@
       <number>2</number>
      </property>
      <item alignment="Qt::AlignmentFlag::AlignHCenter">
-      <widget class="QSvgWidget" name="logoSvgWidget" native="true">
+      <widget class="ClickableSvgWidget" name="logoSvgWidget" native="true">
        <property name="minimumSize">
         <size>
          <width>88</width>
@@ -49,52 +49,6 @@
         </size>
        </property>
       </widget>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="buttonBar" stretch="0,0,0">
-     <property name="spacing">
-      <number>10</number>
-     </property>
-     <property name="topMargin">
-      <number>0</number>
-     </property>
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>500</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="aboutButton">
-       <property name="autoFillBackground">
-        <bool>false</bool>
-       </property>
-       <property name="text">
-        <string>About</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Orientation::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>500</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
      </item>
     </layout>
    </item>
@@ -525,9 +479,9 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QSvgWidget</class>
+   <class>ClickableSvgWidget</class>
    <extends>QWidget</extends>
-   <header>QSvgWidget</header>
+   <header>ClickableSvgWidget.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>

--- a/src/widgets/ClickableSvgWidget.h
+++ b/src/widgets/ClickableSvgWidget.h
@@ -1,0 +1,27 @@
+#ifndef CLICKABLESVGWIDGET_H
+#define CLICKABLESVGWIDGET_H
+
+#include <QSvgWidget>
+#include <QMouseEvent>
+
+class ClickableSvgWidget : public QSvgWidget {
+    Q_OBJECT
+
+public:
+    explicit ClickableSvgWidget(QWidget *parent = nullptr)
+        : QSvgWidget(parent) {}
+
+signals:
+    void clicked();
+
+protected:
+    void mousePressEvent(QMouseEvent *event) override {
+        if (event->button() == Qt::LeftButton) {
+            emit clicked();
+        }
+        // Call the base class implementation to ensure proper event handling
+        QSvgWidget::mousePressEvent(event);
+    }
+};
+
+#endif // CLICKABLESVGWIDGET_H


### PR DESCRIPTION
**Description**

As required on the https://github.com/radareorg/iaito/issues/185 I removed the about button and converted the SVG logo to emit a clickable signal, added a tool tip text too.

![image](https://github.com/user-attachments/assets/3776f878-7879-460a-9036-16bad4ddc502)