### PR TITLE
refactor: replace non-empty QString constructors with QStringLiteral()

### DIFF
--- a/src/common/ColorThemeWorker.cpp
+++ b/src/common/ColorThemeWorker.cpp
@@ -114,11 +114,11 @@ QString ColorThemeWorker::save(const QJsonDocument &theme, const QString &themeN
             continue;
         }
         if (cutterSpecificOptions.contains(it.key())) {
-            fOut.write(QString("#~%1 rgb:%2\n")
+            fOut.write(QStringLiteral("#~%1 rgb:%2\n")
                            .arg(it.key(), color.name(QColor::HexArgb).remove('#'))
                            .toUtf8());
         } else {
-            fOut.write(QString("ec %1 rgb:%2\n")
+            fOut.write(QStringLiteral("ec %1 rgb:%2\n")
                            .arg(it.key(), color.name(QColor::HexRgb).remove('#'))
                            .toUtf8());
         }
@@ -146,9 +146,9 @@ QJsonDocument ColorThemeWorker::getTheme(const QString &themeName) const
     QString curr = Config()->getColorTheme();
 
     if (themeName != curr) {
-        Core()->cmdRaw(QString("eco %1").arg(themeName));
+        Core()->cmdRaw(QStringLiteral("eco %1").arg(themeName));
         theme = Core()->cmdj("ecj").object().toVariantMap();
-        Core()->cmdRaw(QString("eco %1").arg(curr));
+        Core()->cmdRaw(QStringLiteral("eco %1").arg(curr));
     } else {
         theme = Core()->cmdj("ecj").object().toVariantMap();
     }
@@ -294,7 +294,7 @@ bool ColorThemeWorker::isFileTheme(const QString &filePath, bool *ok) const
                           .join('|')
                           .replace(".", "\\.");
 
-    QString pattern = QString("((ec\\s+(%1)\\s+(((rgb:|#)[0-9a-fA-F]{3,8})|(%2))))\\s*")
+    QString pattern = QStringLiteral("((ec\\s+(%1)\\s+(((rgb:|#)[0-9a-fA-F]{3,8})|(%2))))\\s*")
                           .arg(options)
                           .arg(colors);
     // The below construct mimics the behaviour of QRegexP::exactMatch(), which

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -521,7 +521,7 @@ QSyntaxHighlighter *Configuration::createSyntaxHighlighter(QTextDocument *docume
 
 QString Configuration::getLogoFile()
 {
-    return windowColorIsDark() ? QString(":/img/iaito-o-light.svg") : QString(":/img/iaito-o.svg");
+    return windowColorIsDark() ? QStringLiteral(":/img/iaito-o-light.svg") : QStringLiteral(":/img/iaito-o.svg");
 }
 
 /**

--- a/src/common/Helpers.cpp
+++ b/src/common/Helpers.cpp
@@ -198,7 +198,7 @@ QByteArray applyColorToSvg(const QByteArray &data, QColor color)
     static const QRegularExpression styleRegExp(
         "(?:style=\".*fill:(.*?);.*?\")|(?:fill=\"(.*?)\")");
 
-    QString replaceStr = QString("#%1").arg(color.rgb() & 0xffffff, 6, 16, QLatin1Char('0'));
+    QString replaceStr = QStringLiteral("#%1").arg(color.rgb() & 0xffffff, 6, 16, QLatin1Char('0'));
     int replaceStrLen = replaceStr.length();
 
     QString xml = QString::fromUtf8(data);

--- a/src/common/JsonModel.cpp
+++ b/src/common/JsonModel.cpp
@@ -45,10 +45,10 @@ QVariant JsonModel::data(const QModelIndex &index, int role) const
 
     if (role == Qt::DisplayRole) {
         if (index.column() == 0)
-            return QString("%1").arg(item->key());
+            return QStringLiteral("%1").arg(item->key());
 
         if (index.column() == 1)
-            return QString("%1").arg(item->value());
+            return QStringLiteral("%1").arg(item->value());
     }
 
     return QVariant();

--- a/src/common/RichTextPainter.cpp
+++ b/src/common/RichTextPainter.cpp
@@ -103,17 +103,17 @@ void RichTextPainter::htmlRichText(const List &richText, QString &textHtml, QStr
             textHtml += "<span>";
             break;
         case FlagColor: // color only
-            textHtml += QString("<span style=\"color:%1\">").arg(curRichText.textColor.name());
+            textHtml += QStringLiteral("<span style=\"color:%1\">").arg(curRichText.textColor.name());
             break;
         case FlagBackground: // background only
             if (curRichText.textBackground
                 != Qt::transparent) // QColor::name() returns "#000000" for
                                     // transparent color. That's not desired. Leave
                                     // it blank.
-                textHtml += QString("<span style=\"background-color:%1\">")
+                textHtml += QStringLiteral("<span style=\"background-color:%1\">")
                                 .arg(curRichText.textBackground.name());
             else
-                textHtml += QString("<span>");
+                textHtml += QStringLiteral("<span>");
             break;
         case FlagAll: // color+background
             if (curRichText.textBackground
@@ -121,10 +121,10 @@ void RichTextPainter::htmlRichText(const List &richText, QString &textHtml, QStr
                                     // transparent color. That's not desired. Leave
                                     // it blank.
                 textHtml
-                    += QString("<span style=\"color:%1; background-color:%2\">")
+                    += QStringLiteral("<span style=\"color:%1; background-color:%2\">")
                            .arg(curRichText.textColor.name(), curRichText.textBackground.name());
             else
-                textHtml += QString("<span style=\"color:%1\">").arg(curRichText.textColor.name());
+                textHtml += QStringLiteral("<span style=\"color:%1\">").arg(curRichText.textColor.name());
             break;
         }
         if (curRichText.highlight) // Underline highlighted token

--- a/src/common/UpdateWorker.cpp
+++ b/src/common/UpdateWorker.cpp
@@ -60,7 +60,7 @@ void UpdateWorker::download(QString filename, QString version)
 
     QNetworkRequest request;
     request.setAttribute(QNetworkRequest::RedirectPolicyAttribute, true);
-    QUrl url(QString("https://github.com/radareorg/iaito/releases/"
+    QUrl url(QStringLiteral("https://github.com/radareorg/iaito/releases/"
                      "download/v%1/%2")
                  .arg(version)
                  .arg(getRepositoryFileName()));
@@ -79,7 +79,7 @@ void UpdateWorker::showUpdateDialog(bool showDontCheckForUpdatesButton)
         tr("There is an update available for Iaito.<br/>") + "<b>" + tr("Current version:")
         + "</b> " IAITO_VERSION_FULL "<br/>" + "<b>" + tr("Latest version:") + "</b> "
         + latestVersion.toString() + "<br/><br/>" + tr("For update, please check the link:<br/>")
-        + QString("<a href=\"https://github.com/radareorg/iaito/releases/tag/v%1\">"
+        + QStringLiteral("<a href=\"https://github.com/radareorg/iaito/releases/tag/v%1\">"
                   "https://github.com/radareorg/iaito/releases/tag/v%1</a><br/>")
               .arg(latestVersion.toString())
         + tr("or click \"Download\" to download latest version of Iaito."));
@@ -100,15 +100,15 @@ void UpdateWorker::showUpdateDialog(bool showDontCheckForUpdatesButton)
         QString fullFileName = QFileDialog::getSaveFileName(
             nullptr,
             tr("Choose directory for downloading"),
-            QString("%1").arg(r_file_home(NULL)) + QDir::separator() + getRepositoryFileName(),
-            QString("%1 (*.%1)").arg(getRepositeryExt()));
+            QStringLiteral("%1").arg(r_file_home(NULL)) + QDir::separator() + getRepositoryFileName(),
+            QStringLiteral("%1 (*.%1)").arg(getRepositeryExt()));
 #else
         QString fullFileName = QFileDialog::getSaveFileName(
             nullptr,
             tr("Choose directory for downloading"),
             QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + QDir::separator()
                 + getRepositoryFileName(),
-            QString("%1 (*.%1)").arg(getRepositeryExt()));
+            QStringLiteral("%1 (*.%1)").arg(getRepositeryExt()));
 #endif
         if (!fullFileName.isEmpty()) {
             QProgressDialog progressDial(tr("Downloading update..."), tr("Cancel"), 0, 100);

--- a/src/core/Iaito.cpp
+++ b/src/core/Iaito.cpp
@@ -815,7 +815,7 @@ QString IaitoCore::getInstructionOpcode(RVA addr)
 
 void IaitoCore::editInstruction(RVA addr, const QString &inst)
 {
-    cmdRawAt(QString("wa %1").arg(inst), addr);
+    cmdRawAt(QStringLiteral("wa %1").arg(inst), addr);
     emit instructionChanged(addr);
 }
 
@@ -833,13 +833,13 @@ void IaitoCore::jmpReverse(RVA addr)
 
 void IaitoCore::editBytes(RVA addr, const QString &bytes)
 {
-    cmdRawAt(QString("wx %1").arg(bytes), addr);
+    cmdRawAt(QStringLiteral("wx %1").arg(bytes), addr);
     emit instructionChanged(addr);
 }
 
 void IaitoCore::editBytesEndian(RVA addr, const QString &bytes)
 {
-    cmdRawAt(QString("wv %1").arg(bytes), addr);
+    cmdRawAt(QStringLiteral("wv %1").arg(bytes), addr);
     emit stackChanged();
 }
 
@@ -884,7 +884,7 @@ void IaitoCore::setAsString(RVA addr, int size, StringTypeFormats type)
 
     seekAndShow(addr);
 
-    cmdRawAt(QString("%1 %2").arg(command).arg(size), addr);
+    cmdRawAt(QStringLiteral("%1 %2").arg(command).arg(size), addr);
     emit instructionChanged(addr);
 }
 
@@ -905,7 +905,7 @@ void IaitoCore::setToData(RVA addr, int size, int repeat)
         return;
     }
     cmdRawAt("Cd-", addr);
-    cmdRawAt(QString("Cd %1 %2").arg(size).arg(repeat), addr);
+    cmdRawAt(QStringLiteral("Cd %1 %2").arg(size).arg(repeat), addr);
     emit instructionChanged(addr);
 }
 
@@ -918,7 +918,7 @@ int IaitoCore::sizeofDataMeta(RVA addr)
 
 void IaitoCore::setComment(RVA addr, const QString &cmt)
 {
-    cmdRawAt(QString("CCu base64:%1").arg(QString(cmt.toLocal8Bit().toBase64())), addr);
+    cmdRawAt(QStringLiteral("CCu base64:%1").arg(QString(cmt.toLocal8Bit().toBase64())), addr);
     emit commentsChanged(addr);
 }
 
@@ -945,7 +945,7 @@ void IaitoCore::setImmediateBase(const QString &r2BaseName, RVA offset)
         offset = getOffset();
     }
 
-    this->cmdRawAt(QString("ahi %1").arg(r2BaseName), offset);
+    this->cmdRawAt(QStringLiteral("ahi %1").arg(r2BaseName), offset);
     emit instructionChanged(offset);
 }
 
@@ -955,7 +955,7 @@ void IaitoCore::setCurrentBits(int bits, RVA offset)
         offset = getOffset();
     }
 
-    this->cmdRawAt(QString("ahb %1").arg(bits), offset);
+    this->cmdRawAt(QStringLiteral("ahb %1").arg(bits), offset);
     emit instructionChanged(offset);
 }
 
@@ -989,7 +989,7 @@ void IaitoCore::seek(ut64 offset)
     }
 
     // use cmd and not cmdRaw to make sure seekChanged is emitted
-    cmd(QString("s %1").arg(offset));
+    cmd(QStringLiteral("s %1").arg(offset));
     // cmd already does emit seekChanged(core_->offset);
 }
 
@@ -1012,7 +1012,7 @@ void IaitoCore::seekAndShow(QString offset)
 
 void IaitoCore::seek(QString thing)
 {
-    cmdRaw(QString("s %1").arg(thing));
+    cmdRaw(QStringLiteral("s %1").arg(thing));
     updateSeek();
 }
 
@@ -1037,7 +1037,7 @@ RVA IaitoCore::prevOpAddr(RVA startAddr, int count)
 {
     CORE_LOCK();
     bool ok;
-    RVA offset = cmdRawAt(QString("/O %1").arg(count), startAddr).toULongLong(&ok, 16);
+    RVA offset = cmdRawAt(QStringLiteral("/O %1").arg(count), startAddr).toULongLong(&ok, 16);
     return ok ? offset : startAddr - count;
 }
 
@@ -1141,7 +1141,7 @@ QString IaitoCore::getConfigDescription(const char *k)
 {
     CORE_LOCK();
     RConfigNode *node = r_config_node_get(core->config, k);
-    return node ? QString(node->desc) : QString("Unrecognized configuration key");
+    return node ? QString(node->desc) : QStringLiteral("Unrecognized configuration key");
 }
 
 void IaitoCore::triggerRefreshAll()
@@ -1325,7 +1325,7 @@ QString IaitoCore::cmdFunctionAt(QString addr)
 {
     QString ret;
     // Use cmd because cmdRaw would not work with grep
-    ret = cmd(QString("fd @ %1~[0]").arg(addr));
+    ret = cmd(QStringLiteral("fd @ %1~[0]").arg(addr));
     return ret.trimmed();
 }
 
@@ -1346,7 +1346,7 @@ void IaitoCore::cmdEsil(const char *command)
 
 QString IaitoCore::createFunctionAt(RVA addr)
 {
-    QString ret = cmdRaw(QString("af %1").arg(addr));
+    QString ret = cmdRaw(QStringLiteral("af %1").arg(addr));
     emit functionsChanged();
     return ret;
 }
@@ -1355,7 +1355,7 @@ QString IaitoCore::createFunctionAt(RVA addr, QString name)
 {
     static const QRegularExpression regExp("[^a-zA-Z0-9_]");
     name.remove(regExp);
-    QString ret = cmdRawAt(QString("af %1").arg(name), addr);
+    QString ret = cmdRawAt(QStringLiteral("af %1").arg(name), addr);
     emit functionsChanged();
     return ret;
 }
@@ -1694,7 +1694,7 @@ QJsonDocument IaitoCore::getRegisterValues()
 QList<VariableDescription> IaitoCore::getVariables(RVA at)
 {
     QList<VariableDescription> ret;
-    QJsonObject varsObject = cmdj(QString("afvj @ %1").arg(at)).object();
+    QJsonObject varsObject = cmdj(QStringLiteral("afvj @ %1").arg(at)).object();
 
     auto addVars = [&](VariableDescription::RefType refType, const QJsonArray &array) {
         for (const QJsonValue varValue : array) {
@@ -1753,7 +1753,7 @@ RVA IaitoCore::getProgramCounterValue()
 
 void IaitoCore::setRegister(QString regName, QString regValue)
 {
-    cmdRaw(QString("dr %1=%2").arg(regName).arg(regValue));
+    cmdRaw(QStringLiteral("dr %1=%2").arg(regName).arg(regValue));
     emit registersChanged();
     emit refreshCodeViews();
 }
@@ -2000,7 +2000,7 @@ void IaitoCore::stopDebug()
         currentlyEmulating = false;
     } else if (currentlyAttachedToPID != -1) {
         // Use cmd because cmdRaw would not work with command concatenation
-        cmd(QString("dp- %1; o %2; .ar-")
+        cmd(QStringLiteral("dp- %1; o %2; .ar-")
                 .arg(QString::number(currentlyAttachedToPID), currentlyOpenFile));
         currentlyAttachedToPID = -1;
     } else {
@@ -2241,7 +2241,7 @@ void IaitoCore::setDebugPlugin(QString plugin)
 
 void IaitoCore::toggleBreakpoint(RVA addr)
 {
-    cmdRaw(QString("dbs %1").arg(addr));
+    cmdRaw(QStringLiteral("dbs %1").arg(addr));
     emit breakpointsChanged(addr);
 }
 
@@ -2345,9 +2345,9 @@ void IaitoCore::disableBreakpoint(RVA addr)
 void IaitoCore::setBreakpointTrace(int index, bool enabled)
 {
     if (enabled) {
-        cmdRaw(QString("dbite %1").arg(index));
+        cmdRaw(QStringLiteral("dbite %1").arg(index));
     } else {
-        cmdRaw(QString("dbitd %1").arg(index));
+        cmdRaw(QStringLiteral("dbitd %1").arg(index));
     }
 }
 
@@ -2926,7 +2926,7 @@ QList<SymbolDescription> IaitoCore::getAllSymbols()
         {
             SymbolDescription symbol;
             symbol.vaddr = entry->vaddr;
-            symbol.name = QString("entry") + QString::number(n++);
+            symbol.name = QStringLiteral("entry") + QString::number(n++);
             symbol.bind.clear();
             symbol.type = "entry";
             ret << symbol;
@@ -3034,7 +3034,7 @@ QList<RelocDescription> IaitoCore::getAllRelocs()
             if (br->import)
                 reloc.name = r_bin_name_tostring(br->import->name);
             else
-                reloc.name = QString("reloc_%1").arg(QString::number(br->vaddr, 16));
+                reloc.name = QStringLiteral("reloc_%1").arg(QString::number(br->vaddr, 16));
 
             ret << reloc;
         }
@@ -3054,7 +3054,7 @@ QList<RelocDescription> IaitoCore::getAllRelocs()
             if (br->import)
                 reloc.name = br->import->name;
             else
-                reloc.name = QString("reloc_%1").arg(QString::number(br->vaddr, 16));
+                reloc.name = QStringLiteral("reloc_%1").arg(QString::number(br->vaddr, 16));
 
             ret << reloc;
         }
@@ -3072,7 +3072,7 @@ QList<RelocDescription> IaitoCore::getAllRelocs()
             if (br->import)
                 reloc.name = br->import->name;
             else
-                reloc.name = QString("reloc_%1").arg(QString::number(br->vaddr, 16));
+                reloc.name = QStringLiteral("reloc_%1").arg(QString::number(br->vaddr, 16));
 
             ret << reloc;
         }
@@ -3704,13 +3704,13 @@ QString IaitoCore::getTypeAsC(QString name, QString category)
     }
     QString typeName = sanitizeStringForCommand(name);
     if (category == "Struct") {
-        output = cmdRaw(QString("tsc %1").arg(typeName));
+        output = cmdRaw(QStringLiteral("tsc %1").arg(typeName));
     } else if (category == "Union") {
-        output = cmdRaw(QString("tuc %1").arg(typeName));
+        output = cmdRaw(QStringLiteral("tuc %1").arg(typeName));
     } else if (category == "Enum") {
-        output = cmdRaw(QString("tec %1").arg(typeName));
+        output = cmdRaw(QStringLiteral("tec %1").arg(typeName));
     } else if (category == "Typedef") {
-        output = cmdRaw(QString("ttc %1").arg(typeName));
+        output = cmdRaw(QStringLiteral("ttc %1").arg(typeName));
     }
     return output;
 }
@@ -3719,7 +3719,7 @@ bool IaitoCore::isAddressMapped(RVA addr)
 {
     // If value returned by "om. @ addr" is empty means that address is not
     // mapped
-    return !Core()->cmdRawAt(QString("om."), addr).isEmpty();
+    return !Core()->cmdRawAt(QStringLiteral("om."), addr).isEmpty();
 }
 
 QList<SearchDescription> IaitoCore::getAllSearch(QString search_for, QString space)
@@ -3727,7 +3727,7 @@ QList<SearchDescription> IaitoCore::getAllSearch(QString search_for, QString spa
     CORE_LOCK();
     QList<SearchDescription> searchRef;
 
-    QJsonArray searchArray = cmdj(space + QString(" ") + search_for).array();
+    QJsonArray searchArray = cmdj(space + QStringLiteral(" ") + search_for).array();
 
     if (space == "/Rj") {
         for (const QJsonValue value : searchArray) {
@@ -3903,7 +3903,7 @@ QList<XrefDescription> IaitoCore::getXRefs(
         } else {
             xref.to = xrefObject[RJsonKey::to].toVariant().toULongLong();
         }
-        xref.to_str = Core()->cmdRaw(QString("fd %1").arg(xref.to)).trimmed();
+        xref.to_str = Core()->cmdRaw(QStringLiteral("fd %1").arg(xref.to)).trimmed();
 
         xrefList << xref;
     }
@@ -3942,7 +3942,7 @@ QString IaitoCore::listFlagsAsStringAt(RVA addr)
 
 QString IaitoCore::nearestFlag(RVA offset, RVA *flagOffsetOut)
 {
-    auto r = cmdj(QString("fdj @") + QString::number(offset)).object();
+    auto r = cmdj(QStringLiteral("fdj @") + QString::number(offset)).object();
     QString name = r.value("name").toString();
     if (flagOffsetOut) {
         int queryOffset = r.value("offset").toInt(0);
@@ -4011,12 +4011,12 @@ void IaitoCore::triggerFunctionRenamed(const RVA offset, const QString &newName)
 
 void IaitoCore::loadPDB(const QString &file)
 {
-    cmdRaw0(QString("idp ") + sanitizeStringForCommand(file));
+    cmdRaw0(QStringLiteral("idp ") + sanitizeStringForCommand(file));
 }
 
 void IaitoCore::openProject(const QString &name)
 {
-    bool ok = cmdRaw0(QString("'P ") + name); //  + "@e:scr.interactive=false");
+    bool ok = cmdRaw0(QStringLiteral("'P ") + name); //  + "@e:scr.interactive=false");
     if (ok) {
         notes = QString::fromUtf8(QByteArray::fromBase64(cmdRaw("Pnj").toUtf8()));
     } else {
@@ -4031,7 +4031,7 @@ void IaitoCore::openProject(const QString &name)
 void IaitoCore::saveProject(const QString &name)
 {
     Core()->setConfig("scr.interactive", false);
-    const bool ok = cmdRaw0(QString("'Ps ") + name.trimmed());
+    const bool ok = cmdRaw0(QStringLiteral("'Ps ") + name.trimmed());
     if (!ok) {
         QMessageBox::critical(
             nullptr,
@@ -4040,7 +4040,7 @@ void IaitoCore::saveProject(const QString &name)
                "special or uppercase character"));
     }
 #if 0
-    cmdRaw(QString("Pnj %1").arg(QString(notes.toUtf8().toBase64())));
+    cmdRaw(QStringLiteral("Pnj %1").arg(QString(notes.toUtf8().toBase64())));
 #endif
     emit projectSaved(ok, name);
 }
@@ -4063,7 +4063,7 @@ bool IaitoCore::isProjectNameValid(const QString &name)
 QList<DisassemblyLine> IaitoCore::disassembleLines(RVA offset, int lines)
 {
     QJsonArray array
-        = cmdj(QString("pdJ ") + QString::number(lines) + QString(" @ ") + QString::number(offset))
+        = cmdj(QStringLiteral("pdJ ") + QString::number(lines) + QStringLiteral(" @ ") + QString::number(offset))
               .array();
     QList<DisassemblyLine> r;
 
@@ -4110,7 +4110,7 @@ QString IaitoCore::hexdump(RVA address, int size, HexdumpFormats format)
         break;
     }
 
-    return cmdRawAt(QString("%1 %2").arg(command).arg(size), address);
+    return cmdRawAt(QStringLiteral("%1 %2").arg(command).arg(size), address);
 }
 
 QByteArray IaitoCore::hexStringToBytes(const QString &hex)
@@ -4172,11 +4172,11 @@ QString IaitoCore::getVersionInformation()
            {"r_util", &r_util_version},
            /* ... */
            {NULL, NULL}};
-    versionInfo.append(QString("%1 r2\n").arg(R2_GITTAP));
+    versionInfo.append(QStringLiteral("%1 r2\n").arg(R2_GITTAP));
     for (i = 0; vcs[i].name; i++) {
         struct vcs_t *v = &vcs[i];
         const char *name = v->callback();
-        versionInfo.append(QString("%1 %2\n").arg(name, v->name));
+        versionInfo.append(QStringLiteral("%1 %2\n").arg(name, v->name));
     }
     return versionInfo;
 }

--- a/src/core/IaitoCommon.h
+++ b/src/core/IaitoCommon.h
@@ -49,18 +49,18 @@ inline QString RAddressString(RVA addr)
 {
     // return QString::asprintf("%#010" PFMT64x, addr);
     // return QString::asprintf("%#010" PRIx64, addr);
-    return QString("0x%1").arg(addr, 8, 16, QChar('0'));
+    return QStringLiteral("0x%1").arg(addr, 8, 16, QChar('0'));
 }
 
 inline QString RSizeString(RVA size)
 {
-    return QString("0x%1").arg(size, 0, 16);
+    return QStringLiteral("0x%1").arg(size, 0, 16);
     // return QString::asprintf("%#" PRIx64, size);
 }
 
 inline QString RHexString(RVA size)
 {
-    return QString("0x%1").arg(size, 0, 16);
+    return QStringLiteral("0x%1").arg(size, 0, 16);
     // return QString::asprintf("%#" PRIx64, size);
 }
 

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -561,7 +561,7 @@ void MainWindow::openNewFile(InitialOptions &options, bool skipOptionsDialog)
 
     /* Prompt to load filename.r2 script */
     if (options.script.isEmpty()) {
-        QString script = QString("%1.r2").arg(this->filename);
+        QString script = QStringLiteral("%1.r2").arg(this->filename);
         if (r_file_exists(script.toStdString().data())) {
             QMessageBox mb;
             mb.setWindowTitle(tr("Script loading"));
@@ -1138,13 +1138,13 @@ void MainWindow::updateHistoryMenu(QMenu *menu, bool redo)
             QString addressString = RAddressString(offset);
 
             QString toolTip
-                = QString("%1 %2").arg(addressString, name); // show non truncated name in tooltip
+                = QStringLiteral("%1 %2").arg(addressString, name); // show non truncated name in tooltip
 
             name.truncate(MAX_NAME_LENGTH); // TODO:#1904 use common name
                                             // shortening function
-            QString label = QString("%1 (%2)").arg(name, addressString);
+            QString label = QStringLiteral("%1 (%2)").arg(name, addressString);
             if (current) {
-                label = QString("current position (%1)").arg(addressString);
+                label = QStringLiteral("current position (%1)").arg(addressString);
             }
             QAction *action = new QAction(label, menu);
             action->setToolTip(toolTip);

--- a/src/dialogs/AboutDialog.cpp
+++ b/src/dialogs/AboutDialog.cpp
@@ -31,14 +31,14 @@ AboutDialog::AboutDialog(QWidget *parent)
         + buildQtVersionString()
 #if 0
                         + "<p><b>" + tr("Optional Features:") + "</b><br/>"
-                        + QString("Python: %1<br/>").arg(
+                        + QStringLiteral("Python: %1<br/>").arg(
 #ifdef IAITO_ENABLE_PYTHON
                             "ON"
 #else
                             "OFF"
 #endif
                         )
-                        + QString("Python Bindings: %2</p>").arg(
+                        + QStringLiteral("Python Bindings: %2</p>").arg(
 #ifdef IAITO_ENABLE_PYTHON_BINDINGS
                             "ON"
 #else

--- a/src/dialogs/EditVariablesDialog.cpp
+++ b/src/dialogs/EditVariablesDialog.cpp
@@ -59,7 +59,7 @@ void EditVariablesDialog::applyFields()
     }
     VariableDescription desc = ui->dropdownLocalVars->currentData().value<VariableDescription>();
 
-    Core()->cmdRaw(QString("afvt %1 %2").arg(desc.name).arg(ui->typeComboBox->currentText()));
+    Core()->cmdRaw(QStringLiteral("afvt %1 %2").arg(desc.name).arg(ui->typeComboBox->currentText()));
 
     // TODO Remove all those replace once r2 command parser is fixed
     QString newName = ui->nameEdit->text()

--- a/src/dialogs/HexdumpRangeDialog.cpp
+++ b/src/dialogs/HexdumpRangeDialog.cpp
@@ -66,7 +66,7 @@ bool HexdumpRangeDialog::getLengthRadioButtonChecked() const
 
 void HexdumpRangeDialog::setStartAddress(ut64 start)
 {
-    ui->startAddressLineEdit->setText(QString("0x%1").arg(start, 0, 16));
+    ui->startAddressLineEdit->setText(QStringLiteral("0x%1").arg(start, 0, 16));
 }
 
 void HexdumpRangeDialog::openAt(ut64 start)
@@ -89,7 +89,7 @@ bool HexdumpRangeDialog::validate()
         endAddress = Core()->math(ui->endAddressLineEdit->text());
         if (endAddress > startAddress) {
             length = endAddress - startAddress;
-            ui->lengthLineEdit->setText(QString("0x%1").arg(length, 0, 16));
+            ui->lengthLineEdit->setText(QStringLiteral("0x%1").arg(length, 0, 16));
             this->endAddress = endAddress - 1;
             emptyRange = false;
         } else if (endAddress == startAddress) {
@@ -113,9 +113,9 @@ bool HexdumpRangeDialog::validate()
             endAddress = startAddress + length - 1;
             emptyRange = false;
             if (endAddress == UINT64_MAX) {
-                ui->endAddressLineEdit->setText(QString("2^64"));
+                ui->endAddressLineEdit->setText(QStringLiteral("2^64"));
             } else {
-                ui->endAddressLineEdit->setText(QString("0x%1").arg(endAddress + 1, 0, 16));
+                ui->endAddressLineEdit->setText(QStringLiteral("0x%1").arg(endAddress + 1, 0, 16));
             }
         }
     }

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -207,7 +207,7 @@ void InitialOptionsDialog::loadOptions(const InitialOptions &options)
 
 void InitialOptionsDialog::setTooltipWithConfigHelp(QWidget *w, const char *config)
 {
-    w->setToolTip(QString("%1 (%2)").arg(core->getConfigDescription(config)).arg(config));
+    w->setToolTip(QStringLiteral("%1 (%2)").arg(core->getConfigDescription(config)).arg(config));
 }
 
 QString InitialOptionsDialog::getSelectedArch() const
@@ -464,7 +464,7 @@ QString InitialOptionsDialog::analysisDescription(int level)
 
 void InitialOptionsDialog::on_analSlider_valueChanged(int value)
 {
-    ui->analDescription->setText(tr("Level") + QString(": %1").arg(analysisDescription(value)));
+    ui->analDescription->setText(tr("Level") + QStringLiteral(": %1").arg(analysisDescription(value)));
     if (value == 0) {
         ui->analCheckBox->setChecked(false);
         ui->analCheckBox->setText(tr("Analysis: Disabled"));

--- a/src/dialogs/LinkTypeDialog.cpp
+++ b/src/dialogs/LinkTypeDialog.cpp
@@ -63,7 +63,7 @@ void LinkTypeDialog::done(int r)
                 Core()->cmdRaw("tl- " + address);
             } else {
                 // Create link
-                Core()->cmdRaw(QString("tl %1 = %2").arg(type).arg(address));
+                Core()->cmdRaw(QStringLiteral("tl %1 = %2").arg(type).arg(address));
             }
             QDialog::done(r);
 
@@ -88,7 +88,7 @@ QString LinkTypeDialog::findLinkedType(RVA address)
         return QString();
     }
 
-    QString ret = Core()->cmdRaw(QString("tls %1").arg(address));
+    QString ret = Core()->cmdRaw(QStringLiteral("tls %1").arg(address));
     if (ret.isEmpty()) {
         // return empty string since the current address is not linked to a type
         return QString();

--- a/src/dialogs/NewFileDialog.cpp
+++ b/src/dialogs/NewFileDialog.cpp
@@ -311,7 +311,7 @@ bool NewFileDialog::fillRecentFilesList()
         } else {
             // Format the text and add the item to the file list
             const QString text
-                = QString("%1\n%2\nSize: %3")
+                = QStringLiteral("%1\n%2\nSize: %3")
                       .arg(basename, filenameHome, qhelpers::formatBytecount(info.size()));
             QListWidgetItem *item = new QListWidgetItem(getIconFor(basename, i), text);
             item->setData(Qt::UserRole, fullpath);
@@ -436,7 +436,7 @@ void NewFileDialog::loadShellcode(const QString &shellcode, const int size)
 {
     MainWindow *main = new MainWindow();
     InitialOptions options;
-    options.filename = QString("malloc://%1").arg(size);
+    options.filename = QStringLiteral("malloc://%1").arg(size);
     options.shellcode = shellcode;
     main->openNewFile(options);
     close();

--- a/src/dialogs/RemoteDebugDialog.cpp
+++ b/src/dialogs/RemoteDebugDialog.cpp
@@ -154,7 +154,7 @@ void RemoteDebugDialog::fillFormData(QString formdata)
 
     if (backend->type == GDB) {
         // Format is | prefix | IP | : | PORT |
-        int lastColon = formdata.lastIndexOf(QString(":"));
+        int lastColon = formdata.lastIndexOf(QStringLiteral(":"));
         portText = formdata.mid(lastColon + 1, formdata.length());
         ipText = formdata.mid(backend->prefix.length(), lastColon - backend->prefix.length());
     } else if (backend->type == WINDBG) {
@@ -170,9 +170,9 @@ QString RemoteDebugDialog::getUri() const
 {
     int debugger = getDebugger();
     if (debugger == WINDBG) {
-        return QString("%1%2").arg(dbgBackends[WINDBG].prefix, getIpOrPath());
+        return QStringLiteral("%1%2").arg(dbgBackends[WINDBG].prefix, getIpOrPath());
     } else if (debugger == GDB) {
-        return QString("%1%2:%3")
+        return QStringLiteral("%1%2:%3")
             .arg(dbgBackends[GDB].prefix, getIpOrPath(), QString::number(getPort()));
     }
     return "- uri error";
@@ -187,7 +187,7 @@ bool RemoteDebugDialog::fillRecentIpList()
     QMutableListIterator<QString> it(ips);
     while (it.hasNext()) {
         const QString ip = it.next();
-        const QString text = QString("%1").arg(ip);
+        const QString text = QStringLiteral("%1").arg(ip);
         QListWidgetItem *item = new QListWidgetItem(text);
         item->setData(Qt::UserRole, ip);
         // Fill recentsIpListWidget

--- a/src/dialogs/WriteCommandsDialogs.cpp
+++ b/src/dialogs/WriteCommandsDialogs.cpp
@@ -91,7 +91,7 @@ void DuplicateFromOffsetDialog::refresh()
     // Add space every two characters for word wrap in hex sequence
     QRegularExpression re{"(.{2})"};
     QString bytes = Core()
-                        ->cmdRawAt(QString("p8 %1").arg(QString::number(getNBytes())), offestFrom)
+                        ->cmdRawAt(QStringLiteral("p8 %1").arg(QString::number(getNBytes())), offestFrom)
                         .replace(re, "\\1 ");
 
     ui->bytesLabel->setText(bytes.trimmed());

--- a/src/dialogs/XrefsDialog.cpp
+++ b/src/dialogs/XrefsDialog.cpp
@@ -97,7 +97,7 @@ void XrefsDialog::setupPreviewFont()
 void XrefsDialog::setupPreviewColors()
 {
     ui->previewTextEdit->setStyleSheet(
-        QString("QPlainTextEdit { background-color: %1; color: %2; }")
+        QStringLiteral("QPlainTextEdit { background-color: %1; color: %2; }")
             .arg(ConfigColor("gui.background").name())
             .arg(ConfigColor("btext").name()));
 }

--- a/src/dialogs/preferences/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/preferences/AppearanceOptionsWidget.cpp
@@ -297,8 +297,8 @@ QIcon AppearanceOptionsWidget::getIconFromSvg(
     QString data = file.readAll();
     data.replace(
         QRegularExpression(
-            QString("#%1").arg(before.isValid() ? before.name().remove(0, 1) : "[0-9a-fA-F]{6}")),
-        QString("%1").arg(after.name()));
+            QStringLiteral("#%1").arg(before.isValid() ? before.name().remove(0, 1) : "[0-9a-fA-F]{6}")),
+        QStringLiteral("%1").arg(after.name()));
 
     QSvgRenderer svgRenderer(data.toUtf8());
     QPixmap pix(svgRenderer.defaultSize());

--- a/src/dialogs/preferences/ColorThemeEditDialog.cpp
+++ b/src/dialogs/preferences/ColorThemeEditDialog.cpp
@@ -145,7 +145,7 @@ void ColorThemeEditDialog::colorOptionChanged(const QColor &newColor)
 
     Config()->setColor(currOption.optionName, currOption.color);
     if (!ColorThemeWorker::cutterSpecificOptions.contains(currOption.optionName)) {
-        Core()->cmdRaw(QString("ec %1 %2").arg(currOption.optionName).arg(currOption.color.name()));
+        Core()->cmdRaw(QStringLiteral("ec %1 %2").arg(currOption.optionName).arg(currOption.color.name()));
     }
     previewDisasmWidget->colorsUpdatedSlot();
 }

--- a/src/menus/DecompilerContextMenu.cpp
+++ b/src/menus/DecompilerContextMenu.cpp
@@ -414,7 +414,7 @@ void DecompilerContextMenu::actionEditAnnotationTriggered()
     QString os = Core()->cmdRaw("anos");
     QString *s = openTextEditDialog(os, this);
     if (s != nullptr) {
-        Core()->cmdRaw(QString("ano=base64:%1").arg(QString(s->toLocal8Bit().toBase64())));
+        Core()->cmdRaw(QStringLiteral("ano=base64:%1").arg(QString(s->toLocal8Bit().toBase64())));
         this->mainWindow->refreshAll();
     }
 }

--- a/src/menus/DisassemblyContextMenu.cpp
+++ b/src/menus/DisassemblyContextMenu.cpp
@@ -944,7 +944,7 @@ void DisassemblyContextMenu::on_actionEditAnnotation_triggered()
     QString os = Core()->cmdRaw("anos");
     QString *s = openTextEditDialog(os, this);
     if (s != nullptr) {
-        Core()->cmdRaw(QString("ano=base64:%1").arg(QString(s->toLocal8Bit().toBase64())));
+        Core()->cmdRaw(QStringLiteral("ano=base64:%1").arg(QString(s->toLocal8Bit().toBase64())));
         this->mainWindow->refreshAll();
     }
 }
@@ -1195,7 +1195,7 @@ void DisassemblyContextMenu::setBits(int bits)
 void DisassemblyContextMenu::setColor(const char *color)
 {
     if (*color) {
-        Core()->cmd(QString("abc ") + QString(color));
+        Core()->cmd(QStringLiteral("abc ") + QString(color));
     } else {
         Core()->cmd("abc-");
     }

--- a/src/widgets/CallGraph.cpp
+++ b/src/widgets/CallGraph.cpp
@@ -49,7 +49,7 @@ void CallGraphView::showExportDialog()
     if (global) {
         defaultName = "global_callgraph";
     } else {
-        defaultName = QString("callgraph_%1").arg(RAddressString(address));
+        defaultName = QStringLiteral("callgraph_%1").arg(RAddressString(address));
     }
     showExportGraphDialog(defaultName, global ? "agC" : "agc", address);
 }
@@ -81,7 +81,7 @@ void CallGraphView::loadCurrentGraph()
     blockContent.clear();
     blocks.clear();
 
-    QJsonDocument functionsDoc = Core()->cmdj(global ? "agCj" : QString("agcj @ %1").arg(address));
+    QJsonDocument functionsDoc = Core()->cmdj(global ? "agCj" : QStringLiteral("agcj @ %1").arg(address));
     auto nodes = functionsDoc.array();
 
     QHash<QString, uint64_t> idMapping;

--- a/src/widgets/ClassesWidget.cpp
+++ b/src/widgets/ClassesWidget.cpp
@@ -127,7 +127,7 @@ QVariant BinClassesModel::data(const QModelIndex &index, int role) const
             case OFFSET:
                 return meth->addr == RVA_INVALID ? QString() : RAddressString(meth->addr);
             case VTABLE:
-                return meth->vtableOffset < 0 ? QString() : QString("+%1").arg(meth->vtableOffset);
+                return meth->vtableOffset < 0 ? QString() : QStringLiteral("+%1").arg(meth->vtableOffset);
             default:
                 return QVariant();
             }
@@ -171,7 +171,7 @@ QVariant BinClassesModel::data(const QModelIndex &index, int role) const
             case TYPE:
                 return tr("base class");
             case OFFSET:
-                return QString("+%1").arg(base->offset);
+                return QStringLiteral("+%1").arg(base->offset);
             default:
                 return QVariant();
             }
@@ -437,14 +437,14 @@ QVariant AnalClassesModel::data(const QModelIndex &index, int role) const
                 case TYPE:
                     return tr("base");
                 case OFFSET:
-                    return QString("+%1").arg(base.offset);
+                    return QStringLiteral("+%1").arg(base.offset);
                 default:
                     return QVariant();
                 }
             case Qt::DecorationRole:
                 if (index.column() == NAME) {
                     return QIcon(
-                        new SvgIconEngine(QString(":/img/icons/home.svg"), QPalette::WindowText));
+                        new SvgIconEngine(QStringLiteral(":/img/icons/home.svg"), QPalette::WindowText));
                 }
                 return QVariant();
             case VTableRole:
@@ -471,14 +471,14 @@ QVariant AnalClassesModel::data(const QModelIndex &index, int role) const
                     return meth.addr == RVA_INVALID ? QString() : RAddressString(meth.addr);
                 case VTABLE:
                     return meth.vtableOffset < 0 ? QString()
-                                                 : QString("+%1").arg(meth.vtableOffset);
+                                                 : QStringLiteral("+%1").arg(meth.vtableOffset);
                 default:
                     return QVariant();
                 }
             case Qt::DecorationRole:
                 if (index.column() == NAME) {
                     return QIcon(
-                        new SvgIconEngine(QString(":/img/icons/fork.svg"), QPalette::WindowText));
+                        new SvgIconEngine(QStringLiteral(":/img/icons/fork.svg"), QPalette::WindowText));
                 }
                 return QVariant();
             case VTableRole:
@@ -511,7 +511,7 @@ QVariant AnalClassesModel::data(const QModelIndex &index, int role) const
             case Qt::DecorationRole:
                 if (index.column() == NAME) {
                     return QIcon(
-                        new SvgIconEngine(QString(":/img/icons/list.svg"), QPalette::WindowText));
+                        new SvgIconEngine(QStringLiteral(":/img/icons/list.svg"), QPalette::WindowText));
                 }
                 return QVariant();
             case OffsetRole:

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -193,7 +193,7 @@ QPixmap ColorOptionDelegate::getPixmapFromSvg(const QString &fileName, const QCo
         return QPixmap();
     }
     QString data = file.readAll();
-    data.replace(QRegularExpression("#[0-9a-fA-F]{6}"), QString("%1").arg(after.name()));
+    data.replace(QRegularExpression("#[0-9a-fA-F]{6}"), QStringLiteral("%1").arg(after.name()));
 
     QSvgRenderer svgRenderer(data.toUtf8());
     QPixmap pix(QSize(qApp->fontMetrics().height(), qApp->fontMetrics().height()));
@@ -241,7 +241,7 @@ void ColorThemeListView::currentChanged(const QModelIndex &current, const QModel
     ColorOption prev = previous.data(Qt::UserRole).value<ColorOption>();
     Config()->setColor(prev.optionName, prev.color);
     if (ThemeWorker().radare2SpecificOptions.contains(prev.optionName)) {
-        Core()->cmdRaw(QString("ec %1 %2").arg(prev.optionName).arg(prev.color.name()));
+        Core()->cmdRaw(QStringLiteral("ec %1 %2").arg(prev.optionName).arg(prev.color.name()));
     }
 
     QListView::currentChanged(current, previous);
@@ -303,7 +303,7 @@ void ColorThemeListView::blinkTimeout()
     auto updateColor = [](const QString &name, const QColor &color) {
         Config()->setColor(name, color);
         if (ThemeWorker().radare2SpecificOptions.contains(name)) {
-            Core()->cmdRaw(QString("ec %1 %2").arg(name).arg(color.name()));
+            Core()->cmdRaw(QStringLiteral("ec %1 %2").arg(name).arg(color.name()));
         }
     };
 

--- a/src/widgets/Dashboard.cpp
+++ b/src/widgets/Dashboard.cpp
@@ -94,7 +94,7 @@ void Dashboard::updateContents()
     // Add hashes as a pair of Hash Name : Hash Value.
     for (const QString &key : hashes.keys()) {
         // Create a bold QString with the hash name uppercased
-        QString label = QString("<b>%1:</b>").arg(key.toUpper());
+        QString label = QStringLiteral("<b>%1:</b>").arg(key.toUpper());
 
         // Define a Read-Only line edit to display the hash value
         QLineEdit *hashLineEdit = new QLineEdit();

--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -409,7 +409,7 @@ void DebugActions::editRarunProfile()
     QString dbgProfile = Core()->getConfig("dbg.profile");
     if (dbgProfile.isEmpty()) {
         // do not hardcode the default rarun2 profile filename
-        dbgProfile = QString("/tmp/profile.r2.txt");
+        dbgProfile = QStringLiteral("/tmp/profile.r2.txt");
     }
     if (openTextEditDialogFromFile(dbgProfile)) {
         Core()->setConfig("dbg.profile", dbgProfile);

--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -81,7 +81,7 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     connect(qApp, &QApplication::focusChanged, this, [this](QWidget *, QWidget *now) {
         QColor borderColor = this == now ? palette().color(QPalette::Highlight)
                                          : palette().color(QPalette::WindowText).darker();
-        widget()->setStyleSheet(QString("QSplitter { border: %1px solid %2 } \n"
+        widget()->setStyleSheet(QStringLiteral("QSplitter { border: %1px solid %2 } \n"
                                         "QSplitter:hover { border: %1px solid %3 } \n")
                                     .arg(devicePixelRatio())
                                     .arg(borderColor.name())
@@ -719,7 +719,7 @@ bool DisassemblyWidget::eventFilter(QObject *obj, QEvent *event)
                     const QFont &fnt = Config()->getFont();
                     QFontMetrics fm{fnt};
 
-                    QString tooltip = QString("<html><div style=\"font-family: %1; "
+                    QString tooltip = QStringLiteral("<html><div style=\"font-family: %1; "
                                               "font-size: %2pt; white-space: nowrap;\"><div "
                                               "style=\"margin-bottom: "
                                               "10px;\"><strong>Disassembly "
@@ -799,7 +799,7 @@ void DisassemblyWidget::setupFonts()
 
 void DisassemblyWidget::setupColors()
 {
-    mDisasTextEdit->setStyleSheet(QString("QPlainTextEdit { background-color: %1; color: %2; }")
+    mDisasTextEdit->setStyleSheet(QStringLiteral("QPlainTextEdit { background-color: %1; color: %2; }")
                                       .arg(ConfigColor("gui.background").name())
                                       .arg(ConfigColor("btext").name()));
 }

--- a/src/widgets/FunctionsWidget.cpp
+++ b/src/widgets/FunctionsWidget.cpp
@@ -203,9 +203,9 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
         QStringList disasmPreview
             = Core()->getDisassemblyPreview(function.offset, kMaxTooltipDisasmPreviewLines);
         // its slow, so disabled
-        // const QStringList &similar = Core()->cmdList(QString("cgfa @
+        // const QStringList &similar = Core()->cmdList(QStringLiteral("cgfa @
         // %1").arg(function.offset));
-        const QStringList &summary = Core()->cmdList(QString("pdsf @ %1").arg(function.offset));
+        const QStringList &summary = Core()->cmdList(QStringLiteral("pdsf @ %1").arg(function.offset));
         const QFont &fnt = Config()->getFont();
         QFontMetrics fm{fnt};
 
@@ -222,7 +222,7 @@ QVariant FunctionModel::data(const QModelIndex &index, int role) const
             return QVariant();
 
         QString toolTipContent
-            = QString("<html><div style=\"font-family: %1; font-size: %2pt; "
+            = QStringLiteral("<html><div style=\"font-family: %1; font-size: %2pt; "
                       "white-space: nowrap;\">")
                   .arg(fnt.family())
                   .arg(qMax(6, fnt.pointSize() - 1)); // slightly decrease font size, to keep
@@ -643,7 +643,7 @@ void FunctionsWidget::onActionVerticalToggled(bool enable)
  */
 void FunctionsWidget::setTooltipStylesheet()
 {
-    setStyleSheet(QString("QToolTip { border-width: 1px; max-width: %1px;"
+    setStyleSheet(QStringLiteral("QToolTip { border-width: 1px; max-width: %1px;"
                           "opacity: 230; background-color: %2;"
                           "color: %3; border-color: %3;}")
                       .arg(kMaxTooltipWidth)

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -674,11 +674,11 @@ void HexWidget::copy()
     QClipboard *clipboard = QApplication::clipboard();
     if (cursorOnAscii) {
         clipboard->setText(
-            Core()->cmdRawAt(QString("psx %1").arg(selection.size()), selection.start()).trimmed());
+            Core()->cmdRawAt(QStringLiteral("psx %1").arg(selection.size()), selection.start()).trimmed());
     } else {
         clipboard->setText(Core()
                                ->cmdRawAt(
-                                   QString("p8 %1").arg(selection.size()),
+                                   QStringLiteral("p8 %1").arg(selection.size()),
                                    selection.start())
                                .trimmed()); // TODO: copy in the format shown
     }
@@ -713,7 +713,7 @@ void HexWidget::w_writeString()
     d.setInputMode(QInputDialog::InputMode::TextInput);
     QString str = d.getText(this, tr("Write string"), tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmdRawAt(QString("w %1").arg(str), getLocationAddress());
+        Core()->cmdRawAt(QStringLiteral("w %1").arg(str), getLocationAddress());
         refresh();
     }
 }
@@ -730,7 +730,7 @@ void HexWidget::w_increaseDecrease()
     }
     QString mode = d.getMode() == IncrementDecrementDialog::Increase ? "+" : "-";
     Core()->cmdRawAt(
-        QString("w%1%2 %3")
+        QStringLiteral("w%1%2 %3")
             .arg(QString::number(d.getNBytes()))
             .arg(mode)
             .arg(QString::number(d.getValue())),
@@ -754,7 +754,7 @@ void HexWidget::w_writeZeros()
     QString str = QString::number(
         d.getInt(this, tr("Write zeros"), tr("Number of zeros:"), size, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !str.isEmpty()) {
-        Core()->cmdRawAt(QString("w0 %1").arg(str), getLocationAddress());
+        Core()->cmdRawAt(QStringLiteral("w0 %1").arg(str), getLocationAddress());
         refresh();
     }
 }
@@ -785,7 +785,7 @@ void HexWidget::w_write64()
     }
 
     Core()->cmdRawAt(
-        QString("w6%1 %2").arg(mode).arg((mode == "e" ? str.toHex() : str).toStdString().c_str()),
+        QStringLiteral("w6%1 %2").arg(mode).arg((mode == "e" ? str.toHex() : str).toStdString().c_str()),
         getLocationAddress());
     refresh();
 }
@@ -805,7 +805,7 @@ void HexWidget::w_writeRandom()
     QString nbytes = QString::number(
         d.getInt(this, tr("Write random"), tr("Number of bytes:"), size, 1, 0x7FFFFFFF, 1, &ok));
     if (ok && !nbytes.isEmpty()) {
-        Core()->cmdRawAt(QString("wr %1").arg(nbytes), getLocationAddress());
+        Core()->cmdRawAt(QStringLiteral("wr %1").arg(nbytes), getLocationAddress());
         refresh();
     }
 }
@@ -822,7 +822,7 @@ void HexWidget::w_duplFromOffset()
     }
     RVA copyFrom = d.getOffset();
     QString nBytes = QString::number(d.getNBytes());
-    Core()->cmdRawAt(QString("wd %1 %2").arg(copyFrom).arg(nBytes), getLocationAddress());
+    Core()->cmdRawAt(QStringLiteral("wd %1 %2").arg(copyFrom).arg(nBytes), getLocationAddress());
     refresh();
 }
 
@@ -837,7 +837,7 @@ void HexWidget::w_writePascalString()
     QString str
         = d.getText(this, tr("Write Pascal string"), tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmdRawAt(QString("ws %1").arg(str), getLocationAddress());
+        Core()->cmdRawAt(QStringLiteral("ws %1").arg(str), getLocationAddress());
         refresh();
     }
 }
@@ -853,7 +853,7 @@ void HexWidget::w_writeWideString()
     QString str
         = d.getText(this, tr("Write wide string"), tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmdRawAt(QString("ww %1").arg(str), getLocationAddress());
+        Core()->cmdRawAt(QStringLiteral("ww %1").arg(str), getLocationAddress());
         refresh();
     }
 }
@@ -869,7 +869,7 @@ void HexWidget::w_writeCString()
     QString str = d.getText(
         this, tr("Write zero-terminated string"), tr("String:"), QLineEdit::Normal, "", &ok);
     if (ok && !str.isEmpty()) {
-        Core()->cmdRawAt(QString("wz %1").arg(str), getLocationAddress());
+        Core()->cmdRawAt(QStringLiteral("wz %1").arg(str), getLocationAddress());
         refresh();
     }
 }
@@ -992,7 +992,7 @@ void HexWidget::drawAddrArea(QPainter &painter)
     painter.setPen(addrColor);
     for (int line = 0; line < visibleLines && offset <= data->maxIndex();
          ++line, strRect.translate(0, lineHeight), offset += itemRowByteLen()) {
-        addrString = QString("%1").arg(offset, addrCharLen, 16, QLatin1Char('0'));
+        addrString = QStringLiteral("%1").arg(offset, addrCharLen, 16, QLatin1Char('0'));
         if (showExAddr)
             addrString.prepend(hexPrefix);
         painter.drawText(strRect, Qt::AlignVCenter, addrString);
@@ -1444,21 +1444,21 @@ QString HexWidget::renderItem(int offset, QColor *color)
     // FIXME: handle broken itemVal ( QVariant() )
     switch (itemFormat) {
     case ItemFormatHex:
-        item = QString("%1").arg(itemVal.toULongLong(), itemLen, 16, QLatin1Char('0'));
+        item = QStringLiteral("%1").arg(itemVal.toULongLong(), itemLen, 16, QLatin1Char('0'));
         if (itemByteLen > 1 && showExHex)
             item.prepend(hexPrefix);
         break;
     case ItemFormatOct:
-        item = QString("%1").arg(itemVal.toULongLong(), itemLen, 8, QLatin1Char('0'));
+        item = QStringLiteral("%1").arg(itemVal.toULongLong(), itemLen, 8, QLatin1Char('0'));
         break;
     case ItemFormatDec:
-        item = QString("%1").arg(itemVal.toULongLong(), itemLen, 10);
+        item = QStringLiteral("%1").arg(itemVal.toULongLong(), itemLen, 10);
         break;
     case ItemFormatSignedDec:
-        item = QString("%1").arg(itemVal.toLongLong(), itemLen, 10);
+        item = QStringLiteral("%1").arg(itemVal.toLongLong(), itemLen, 10);
         break;
     case ItemFormatFloat:
-        item = QString("%1").arg(itemVal.toDouble(), itemLen);
+        item = QStringLiteral("%1").arg(itemVal.toDouble(), itemLen);
         break;
     }
 

--- a/src/widgets/HexdumpWidget.cpp
+++ b/src/widgets/HexdumpWidget.cpp
@@ -240,20 +240,20 @@ void HexdumpWidget::updateParseWindow(RVA start_address, int size)
 
         ui->hexDisasTextEdit->setPlainText(
             selectedCommand != ""
-                ? Core()->cmdRawAt(QString("%1 %2").arg(selectedCommand).arg(size), start_address)
+                ? Core()->cmdRawAt(QStringLiteral("%1 %2").arg(selectedCommand).arg(size), start_address)
                 : "");
     } else {
         // Fill the information tab hashes and entropy
         ui->bytesMD5->setText(
-            Core()->cmdRawAt(QString("ph md5 %1").arg(size), start_address).trimmed());
+            Core()->cmdRawAt(QStringLiteral("ph md5 %1").arg(size), start_address).trimmed());
         ui->bytesSHA1->setText(
-            Core()->cmdRawAt(QString("ph sha1 %1").arg(size), start_address).trimmed());
+            Core()->cmdRawAt(QStringLiteral("ph sha1 %1").arg(size), start_address).trimmed());
         ui->bytesSHA256->setText(
-            Core()->cmdRawAt(QString("ph sha256 %1").arg(size), start_address).trimmed());
+            Core()->cmdRawAt(QStringLiteral("ph sha256 %1").arg(size), start_address).trimmed());
         ui->bytesCRC32->setText(
-            Core()->cmdRawAt(QString("ph crc32 %1").arg(size), start_address).trimmed());
+            Core()->cmdRawAt(QStringLiteral("ph crc32 %1").arg(size), start_address).trimmed());
         ui->bytesEntropy->setText(
-            Core()->cmdRawAt(QString("ph entropy %1").arg(size), start_address).trimmed());
+            Core()->cmdRawAt(QStringLiteral("ph entropy %1").arg(size), start_address).trimmed());
         ui->bytesMD5->setCursorPosition(0);
         ui->bytesSHA1->setCursorPosition(0);
         ui->bytesSHA256->setCursorPosition(0);

--- a/src/widgets/IaitoGraphView.cpp
+++ b/src/widgets/IaitoGraphView.cpp
@@ -371,7 +371,7 @@ void IaitoGraphView::exportR2GraphvizGraph(
 {
     TempConfig tempConfig;
     tempConfig.set("graph.gv.format", type);
-    qWarning() << Core()->cmdRawAt(QString("%0w \"%1\"").arg(graphCommand).arg(filePath), address);
+    qWarning() << Core()->cmdRawAt(QStringLiteral("%0w \"%1\"").arg(graphCommand).arg(filePath), address);
 }
 
 void IaitoGraphView::exportR2TextGraph(QString filePath, QString graphCommand, RVA address)
@@ -382,7 +382,7 @@ void IaitoGraphView::exportR2TextGraph(QString filePath, QString graphCommand, R
         return;
     }
     QTextStream fileOut(&file);
-    fileOut << Core()->cmdRawAt(QString("%0").arg(graphCommand), address);
+    fileOut << Core()->cmdRawAt(QStringLiteral("%0").arg(graphCommand), address);
 }
 
 bool IaitoGraphView::graphIsBitamp(IaitoGraphView::GraphExportType type)

--- a/src/widgets/R2GraphWidget.cpp
+++ b/src/widgets/R2GraphWidget.cpp
@@ -61,7 +61,7 @@ void R2GraphWidget::typeChanged()
         ui->customCommand->setFocus();
     } else {
         ui->customCommand->setVisible(false);
-        auto command = QString("ag%1").arg(currentData.toChar());
+        auto command = QStringLiteral("ag%1").arg(currentData.toChar());
         graphView->setGraphCommand(command);
         graphView->refreshView();
     }
@@ -97,7 +97,7 @@ void GenericR2GraphView::loadCurrentGraph()
         return;
     }
 
-    QJsonDocument functionsDoc = Core()->cmdj(QString("%1j").arg(graphCommand));
+    QJsonDocument functionsDoc = Core()->cmdj(QStringLiteral("%1j").arg(graphCommand));
     auto nodes = functionsDoc.object()["nodes"].toArray();
 
     for (const QJsonValueRef value : nodes) {

--- a/src/widgets/RelocsWidget.cpp
+++ b/src/widgets/RelocsWidget.cpp
@@ -24,10 +24,10 @@ int RelocsModel::columnCount(const QModelIndex &) const
 static QString safety(RelocsModel *model, QString name)
 {
     if (model->thread_banned.match(name).hasMatch()) {
-        return QString("Global");
+        return QStringLiteral("Global");
     }
     if (model->unsafe_banned.match(name).hasMatch()) {
-        return QString("Unsafe");
+        return QStringLiteral("Unsafe");
     }
     return QString("");
 }

--- a/src/widgets/SearchWidget.cpp
+++ b/src/widgets/SearchWidget.cpp
@@ -98,7 +98,7 @@ QVariant SearchModel::data(const QModelIndex &index, int role) const
         QFontMetrics fm{fnt};
 
         QString toolTipContent
-            = QString("<html><div style=\"font-family: %1; font-size: %2pt; "
+            = QStringLiteral("<html><div style=\"font-family: %1; font-size: %2pt; "
                       "white-space: nowrap;\">")
                   .arg(fnt.family())
                   .arg(qMax(6, fnt.pointSize() - 1)); // slightly decrease font size, to keep
@@ -193,7 +193,7 @@ SearchWidget::SearchWidget(MainWindow *main)
     , ui(new Ui::SearchWidget)
 {
     ui->setupUi(this);
-    setStyleSheet(QString("QToolTip { max-width: %1px; opacity: 230; }").arg(kMaxTooltipWidth));
+    setStyleSheet(QStringLiteral("QToolTip { max-width: %1px; opacity: 230; }").arg(kMaxTooltipWidth));
 
     updateSearchBoundaries();
 

--- a/src/widgets/SectionsWidget.cpp
+++ b/src/widgets/SectionsWidget.cpp
@@ -446,7 +446,7 @@ void AbstractAddrDock::drawIndicator(QString name, float ratio)
     }
 
     addTextItem(color, QPoint(rectOffset + getRectWidth(), y - indicatorParamPosY), name);
-    addTextItem(color, QPoint(0, y - indicatorParamPosY), QString("0x%1").arg(offset, 0, 16));
+    addTextItem(color, QPoint(0, y - indicatorParamPosY), QStringLiteral("0x%1").arg(offset, 0, 16));
 }
 
 AddrDockScene::AddrDockScene(QWidget *parent)

--- a/src/widgets/SymbolsWidget.cpp
+++ b/src/widgets/SymbolsWidget.cpp
@@ -34,7 +34,7 @@ QVariant SymbolsModel::data(const QModelIndex &index, int role) const
         case SymbolsModel::AddressColumn:
             return RAddressString(symbol.vaddr);
         case SymbolsModel::TypeColumn:
-            return QString("%1 %2").arg(symbol.bind, symbol.type).trimmed();
+            return QStringLiteral("%1 %2").arg(symbol.bind, symbol.type).trimmed();
         case SymbolsModel::NameColumn:
             return symbol.name;
         case SymbolsModel::CommentColumn:


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->

Qt provides a macro [`QStringLiteral()`](https://doc.qt.io/qt-6/qstring.html#QStringLiteral), which avoids the overhead of constructing `QString` objects during runtime.