### PR TITLE
Rename m1 to arm64 for mac builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
       with:
         name: iaito-x64.dmg
         path: build/iaito.dmg
-  acr-macos-m1:
+  acr-macos-arm64:
     runs-on: macos-latest
     steps:
     - uses: actions/checkout@v4
@@ -125,7 +125,7 @@ jobs:
       run: macdeployqt iaito.app -dmg -verbose=2
     - uses: actions/upload-artifact@v4
       with:
-        name: iaito-m1.dmg
+        name: iaito-arm64.dmg
         path: build/iaito.dmg
   meson:
     runs-on: ${{ matrix.os }}
@@ -222,7 +222,7 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag }}
     needs:
       - acr-linux
-      - acr-macos-m1
+      - acr-macos-arm64
       - acr-macos-x64
       - w64-meson
     runs-on: ubuntu-latest
@@ -286,14 +286,14 @@ jobs:
           asset_path: dist/artifacts/iaito-x64.dmg/iaito.dmg
           asset_name: iaito_${{ steps.version.outputs.string }}_x64.dmg
           asset_content_type: application/vnd.debian.binary-package
-      - name: Upload macOS m1 asset
+      - name: Upload macOS arm64 asset
         uses: actions/upload-release-asset@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: dist/artifacts/iaito-m1.dmg/iaito.dmg
-          asset_name: iaito_${{ steps.version.outputs.string }}_m1.dmg
+          asset_path: dist/artifacts/iaito-arm64.dmg/iaito.dmg
+          asset_name: iaito_${{ steps.version.outputs.string }}_arm64.dmg
           asset_content_type: application/vnd.debian.binary-package
       - name: Upload Windows QtDeploy asset
         uses: actions/upload-release-asset@v1


### PR DESCRIPTION
As it has been requested:
https://github.com/radareorg/iaito/issues/170#issuecomment-2130003128

This PR intends to change all artifact names from `m1` to `arm64`.

This does not change the download URL to install radare2, so it is not required to wait until this gets merged and released:
https://github.com/radareorg/radare2/pull/23845