### PR TITLE
Remove extra "0x" prefix when displaying registers

### DIFF
--- a/src/widgets/RegistersWidget.cpp
+++ b/src/widgets/RegistersWidget.cpp
@@ -47,14 +47,12 @@ void RegistersWidget::setRegisterGrid()
 {
     int i = 0;
     int col = 0;
-    QString regValue;
     QLabel *registerLabel;
     QLineEdit *registerEditValue;
     const auto registerRefs = Core()->getRegisterRefValues();
 
     registerLen = registerRefs.size();
     for (auto &reg : registerRefs) {
-        regValue = "0x" + reg.value;
         // check if we already filled this grid space with label/value
         if (!registerLayout->itemAtPosition(i, col)) {
             registerLabel = new QLabel;
@@ -96,7 +94,7 @@ void RegistersWidget::setRegisterGrid()
             registerEditValue = qobject_cast<QLineEdit *>(regValueWidget);
         }
         // decide to highlight QLine Box in case of change of register value
-        if (regValue != registerEditValue->text() && registerEditValue->text() != "") {
+        if (reg.value != registerEditValue->text() && registerEditValue->text() != "") {
             registerEditValue->setStyleSheet("border: 1px solid green;");
         } else {
             // reset stylesheet
@@ -108,8 +106,8 @@ void RegistersWidget::setRegisterGrid()
         registerLabel->setToolTip(reg.ref);
         registerEditValue->setToolTip(reg.ref);
 
-        registerEditValue->setPlaceholderText(regValue);
-        registerEditValue->setText(regValue);
+        registerEditValue->setPlaceholderText(reg.value);
+        registerEditValue->setText(reg.value);
         i++;
         // decide if we should change column
         if (i >= (registerLen + numCols - 1) / numCols) {


### PR DESCRIPTION
radare2 prefixes register values with 0x in the output of `drrj` since version 5.9.0 (commit https://github.com/radareorg/radare2/commit/e424a1b611d3e16abbcaeef288e7658c07a513e0).

**Checklist**

- [ ] Closing issues: #issue
- [x] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->

Right now the registers widget displays value with double 0x prefix, this commit fixes it.

Before:

![registers widget before](https://github.com/user-attachments/assets/aebbd4db-2107-40db-bbee-51bc9086b017)

After:

![registers widget before](https://github.com/user-attachments/assets/03f9b8a6-be6c-445b-9cac-d87b72a6cb77)

