### PR TITLE
Update radare2 to version 6.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: iaito CI
 
 env:
-  R2V: 5.9.8
+  R2V: 6.0.0
 
 on:
   push:
@@ -198,6 +198,7 @@ jobs:
         curl -L -o r2.zip https://github.com/radareorg/radare2/releases/download/${{env.R2V}}/radare2-${{env.R2V}}-w64.zip
         7z x r2.zip
         mv radare2-${{env.R2V}}-w64 radare2
+        cp -f radare2/include/libr/r_util/r_event.h radare2/include/libr/r_event.h || true # workarround fixed on radareorg/radare2@266319b0902603545d94dc35f9c4404b0a2b3a36
         echo "%CD%\radare2\bin" >> $GITHUB_PATH
     - name: configure
       shell: cmd
@@ -209,7 +210,7 @@ jobs:
       run: make.bat -Dwith_qt6=true
     - name: dist
       shell: cmd
-      run: 7z a -r iaito.zip iaito
+      run: 7z a iaito.zip iaito
     - uses: actions/upload-artifact@v4
       with:
         name: iaito-w64.exe

--- a/dist/macos/scripts/embed-radare2.sh
+++ b/dist/macos/scripts/embed-radare2.sh
@@ -10,7 +10,7 @@ R2V=$(readlink "${R2DIR}/lib/radare2/last")
 fix_binary() {
   echo "Change library paths for \"$1\"..."
   ARGS=$(otool -L "$1" | awk '/\/usr\/local\/lib\/libr_/{dst=$1; sub(/\/usr\/local\/lib/,"@executable_path/../Frameworks", dst); print "-change "$1" "dst}')
-  [ -n "$ARGS" ] && install_name_tool $ARGS "$1"
+  [ -z "$ARGS" ] || install_name_tool $ARGS "$1"
 }
 
 mkdir -p \


### PR DESCRIPTION
- Updated CI radare to 6.0.0
- Fix w64 artifact contents (now only contain the resulted build files)
- Fixed issue when embedding static r2 binaries
- Added a workaround for https://github.com/radareorg/radare2/commit/266319b0902603545d94dc35f9c4404b0a2b3a36