### PR TITLE
Fix Qt5/Qt6 build compatibility by replacing QVariant::typeId() with version-safe helper

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -16,6 +16,19 @@
 #include "common/ResourcePaths.h"
 #include "common/SyntaxHighlighter.h"
 
+#include <QVariant>
+#include <QMetaType>
+
+namespace {
+static inline int variantTypeId(const QVariant &v) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return v.metaType().id();
+#else
+    return v.userType();
+#endif
+}
+} // namespace
+
 /* Map with names of themes associated with its color palette
  * (Dark or Light), so for dark interface themes will be shown only Dark color
  * themes and for light - only light ones.
@@ -628,7 +641,7 @@ QVariant Configuration::getConfigVar(const QString &key)
 {
     QHash<QString, QVariant>::const_iterator it = asmOptions.find(key);
     if (it != asmOptions.end()) {
-        switch (it.value().typeId()) {
+        switch (variantTypeId(it.value())) {
         case QMetaType::Bool:
             return Core()->getConfigb(key);
         case QMetaType::Int:

--- a/src/common/TempConfig.cpp
+++ b/src/common/TempConfig.cpp
@@ -4,10 +4,20 @@
 #include "TempConfig.h"
 #include "core/Iaito.h"
 
+namespace {
+static inline int variantTypeId(const QVariant &v) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return v.metaType().id();
+#else
+    return v.userType();
+#endif
+}
+} // namespace
+
 TempConfig::~TempConfig()
 {
     for (auto i = resetValues.constBegin(); i != resetValues.constEnd(); ++i) {
-        switch (i.value().typeId()) {
+        switch (variantTypeId(i.value())) {
         case QMetaType::QString:
             Core()->setConfig(i.key(), i.value().toString());
             break;

--- a/src/widgets/BoolToggleDelegate.cpp
+++ b/src/widgets/BoolToggleDelegate.cpp
@@ -1,5 +1,17 @@
 #include "BoolToggleDelegate.h"
 #include <QEvent>
+#include <QVariant>
+#include <QMetaType>
+
+namespace {
+static inline int variantTypeId(const QVariant &v) {
+#if QT_VERSION >= QT_VERSION_CHECK(6, 0, 0)
+    return v.metaType().id();
+#else
+    return v.userType();
+#endif
+}
+} // namespace
 
 BoolTogggleDelegate::BoolTogggleDelegate(QObject *parent)
     : QStyledItemDelegate(parent)
@@ -8,7 +20,7 @@ BoolTogggleDelegate::BoolTogggleDelegate(QObject *parent)
 QWidget *BoolTogggleDelegate::createEditor(
     QWidget *parent, const QStyleOptionViewItem &option, const QModelIndex &index) const
 {
-    if (index.data(Qt::EditRole).typeId() == QMetaType::Bool) {
+    if (variantTypeId(index.data(Qt::EditRole)) == QMetaType::Bool) {
         return nullptr;
     }
     return QStyledItemDelegate::createEditor(parent, option, index);
@@ -23,7 +35,7 @@ bool BoolTogggleDelegate::editorEvent(
     if (model->flags(index).testFlag(Qt::ItemFlag::ItemIsEditable)) {
         if (event->type() == QEvent::MouseButtonDblClick) {
             auto data = index.data(Qt::EditRole);
-            if (data.typeId() == QMetaType::Bool) {
+            if (variantTypeId(data) == QMetaType::Bool) {
                 model->setData(index, !data.toBool());
                 return true;
             }


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [ ] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->
