### PR TITLE
Update deb builds to use QT6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,7 @@ jobs:
     - name: make indent
       run: make indent && git diff --exit-code
   acr-linux:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v5
       with:
@@ -71,14 +71,15 @@ jobs:
     - name: apt dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libgraphviz-dev mesa-common-dev ninja-build libqt5svg5-dev qttools5-dev qttools5-dev-tools qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools
+        sudo apt-get install -y libgraphviz-dev mesa-common-dev ninja-build qt6-base-dev qt6-declarative-dev libqt6svg6-dev qt6-l10n-tools
+        echo /usr/lib/qt6/bin >> $GITHUB_PATH
     - name: install r2
       run: |
         wget -q https://github.com/radareorg/radare2/releases/download/${{env.R2V}}/radare2_${{env.R2V}}_amd64.deb
         wget -q https://github.com/radareorg/radare2/releases/download/${{env.R2V}}/radare2-dev_${{env.R2V}}_amd64.deb
         sudo dpkg -i *.deb
     - name: configure iaito
-      run: ./configure --prefix=/usr
+      run: ./configure --prefix=/usr --with-qmake6
     - name: build iaito
       run: make -j4
     - name: packaging

--- a/dist/debian/CONFIG
+++ b/dist/debian/CONFIG
@@ -1,7 +1,7 @@
 NAME=iaito
 SECTION=editors
 PRIORITY=optional
-DEPENDS=$(shell ../getpkgversions.sh radare2 libqt5core5a libqt5gui5 libqt5widgets5 libqt5network5 libqt5svg5)
+DEPENDS=$(shell ../getpkgversions.sh radare2), libqt6core6 (>= 6.2.4), libqt6gui6 (>= 6.2.4), libqt6widgets6 (>= 6.2.4), libqt6network6 (>= 6.2.4), libqt6svg6 (>= 6.2.4), libqt6svgwidgets6 (>= 6.2.4), qt6-qpa-plugins (>= 6.2.4)
 MAINTAINER=pancake <pancake@nopcode.org>
 ARCH?=amd64
 VERSION=$(shell ../../../configure -qV)


### PR DESCRIPTION
Update deb builds to use Ubuntu 22.04 and QT6.

To support from debian 12 and ubuntu 22.04.
This should fix #244 