### PR TITLE
Fix deb dist builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,9 @@ jobs:
     - name: make indent
       run: make indent && git diff --exit-code
   acr-linux:
-    runs-on: ubuntu-24.04
+    # required ubuntu-22.04 to support debian oldstable + ubuntu
+    # consider using github actions native container build when the runner get obsolete
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v5
       with:


### PR DESCRIPTION
Reverts commit 97bdad44dc4258fb95f61de21144d08110fdb9fa since it has been discussed and the change is not needed in this specific job.

This change aims to fix #244.