### PR TITLE
Fix segfault when opening X-refs window

### DIFF
--- a/src/widgets/AddressableItemList.h
+++ b/src/widgets/AddressableItemList.h
@@ -76,7 +76,8 @@ public:
             &QItemSelectionModel::currentChanged,
             this,
             &AddressableItemList<BaseListWidget>::onSelectedItemChanged);
-        IaitoTreeView::setModel((QAbstractItemModel *) model);
+        auto cast_model = dynamic_cast<QAbstractItemModel *>(model);
+        IaitoTreeView::setModel(cast_model);
     }
 
     void setMainWindow(MainWindow *mainWindow)


### PR DESCRIPTION
**Checklist**

- [X] Closing issues: #265 
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests: no unit test possible, but solves the crash in my environment (see linked issue)
- [ ] I wrote some documentation

**Description**

This patch fixes a segfault when opening the “Show X-Refs” window. Using a C-style cast can create invalid pointers if used for polymorphic casting when multiple inheritance is involved. Switching to a `dynamic_cast` ensures a correct cast, adjusting the pointer to the desired subobject if necessary.

