### PR TITLE
Sanitize filesystem paths before issuing radare2 fs commands

### DIFF
--- a/src/widgets/FilesystemWidget.cpp
+++ b/src/widgets/FilesystemWidget.cpp
@@ -1,5 +1,6 @@
 #include "FilesystemWidget.h"
 #include "common/Helpers.h"
+#include "core/Iaito.h"
 #include "core/MainWindow.h"
 #include <QContextMenuEvent>
 #include <QInputDialog>
@@ -29,7 +30,8 @@ void FilesystemTreeModel::refresh()
 
 QJsonDocument FilesystemTreeModel::parseMdCommand(const QString &path)
 {
-    QString output = Core()->cmdRaw(QString("mdj %1").arg(path));
+    QString sanitizedPath = IaitoCore::sanitizeStringForCommand(path);
+    QString output = Core()->cmdRaw(QString("mdj %1").arg(sanitizedPath));
     QJsonParseError error;
     QJsonDocument doc = QJsonDocument::fromJson(output.toUtf8(), &error);
     if (error.error != QJsonParseError::NoError) {
@@ -413,7 +415,8 @@ void FilesystemWidget::onTreeContextMenu(const QPoint &pos)
 
 void FilesystemWidget::viewFileContents(const QString &path)
 {
-    QString cmd = QString("mc %1").arg(path);
+    QString sanitizedPath = IaitoCore::sanitizeStringForCommand(path);
+    QString cmd = QString("mc %1").arg(sanitizedPath);
     QString output = Core()->cmdRaw(cmd.toUtf8().constData());
     if (!output.isEmpty()) {
         QMessageBox::information(this, tr("File Contents"), output);
@@ -432,7 +435,8 @@ void FilesystemWidget::deleteFile(const QString &path)
 
 void FilesystemWidget::loadIntoMalloc(const QString &path)
 {
-    QString cmd = QString("mo %1").arg(path);
+    QString sanitizedPath = IaitoCore::sanitizeStringForCommand(path);
+    QString cmd = QString("mo %1").arg(sanitizedPath);
     Core()->cmdRaw(cmd.toUtf8().constData());
     QMessageBox::information(this, tr("Success"), tr("File loaded into malloc."));
 }


### PR DESCRIPTION
### Motivation
- Prevent command injection by sanitizing filesystem entry names before they are interpolated into raw radare2 commands, because untrusted names were previously embedded verbatim into `mdj`, `mc`, and `mo` invocations.

### Description
- Add `#include "core/Iaito.h"` and use `IaitoCore::sanitizeStringForCommand()` to sanitize paths before use. 
- Use the sanitized path in `FilesystemTreeModel::parseMdCommand()` when running `mdj` to enumerate directories. 
- Use the sanitized path in `FilesystemWidget::viewFileContents()` and `FilesystemWidget::loadIntoMalloc()` when issuing `mc` and `mo` commands. 
- Changes are limited to `src/widgets/FilesystemWidget.cpp` and only alter how paths are passed to radare2 commands.

### Testing
- Verified the sanitizer is applied by running `rg "sanitizeStringForCommand\(path\)|mdj %1|mc %1|mo %1" -n src/widgets/FilesystemWidget.cpp`, which found the updated call sites. 
- Attempted `./configure` to validate the build, but it failed in this environment due to a missing radare2 dependency (`checking for r2... error: This program is required.`), so full build/test could not be completed here. 
- No repository unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aacf81f81c83318949a7d3372612f3)