### PR TITLE
Sanitize FilesWidget open command parameters before cmdRaw execution

### DIFF
--- a/src/widgets/FilesWidget.cpp
+++ b/src/widgets/FilesWidget.cpp
@@ -107,11 +107,11 @@ void FilesWidget::onOpenButtonClicked()
     if (filename.isEmpty()) {
         return;
     }
-    QString target = prefix + filename;
+    QString target = IaitoCore::sanitizeStringForCommand(prefix + filename);
     bool parse = parseCheck->isChecked();
     QString cmd;
     if (parse) {
-        QString base = baseAddrEdit->text().trimmed();
+        QString base = IaitoCore::sanitizeStringForCommand(baseAddrEdit->text().trimmed());
         if (!base.isEmpty()) {
             cmd = QString("o %1 %2").arg(target, base);
         } else {


### PR DESCRIPTION
### Motivation
- Prevent command-injection when the Files widget builds raw radare2 commands from untrusted UI inputs (filename and base address) before calling `Core()->cmdRaw()`.

### Description
- Sanitize the combined URI target (`prefix + filename`) with `IaitoCore::sanitizeStringForCommand()` in `FilesWidget::onOpenButtonClicked()` before interpolating it into `o`/`on` commands.
- Sanitize the optional base-address input from `baseAddrEdit` with `IaitoCore::sanitizeStringForCommand()` before appending it to the `o` command, preserving existing behavior while removing command separators.

### Testing
- Ran `./configure` in this environment, which failed due to a missing system `r2` dependency (so no full build could be produced).
- Attempted `make -j8`, which failed because `config.mk` was not generated due to the failed `configure` step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad380fac483318cae34667365dd1e)