### PR TITLE
Fix command injection in MapsWidget bank handling

### DIFF
--- a/src/widgets/MapsWidget.cpp
+++ b/src/widgets/MapsWidget.cpp
@@ -222,7 +222,7 @@ void MapsWidget::loadBanks()
         auto id = o["id"].toInt();
         auto name = o["name"].toString();
         auto row = QStringLiteral("%1 %2").arg(id).arg(name);
-        bankCombo->addItem(row);
+        bankCombo->addItem(row, id);
     }
     bankCombo->blockSignals(false);
     if (bankCombo->count() > 0) {
@@ -233,8 +233,12 @@ void MapsWidget::loadBanks()
 
 void MapsWidget::onBankChanged(int idx)
 {
-    QString bank = bankCombo->itemText(idx);
-    Core()->cmd(QString("omb %1").arg(bank));
+    bool ok = false;
+    int bankId = bankCombo->itemData(idx).toInt(&ok);
+    if (!ok) {
+        return;
+    }
+    Core()->cmd(QString("omb %1").arg(bankId));
     refreshMaps();
 }
 
@@ -246,7 +250,8 @@ void MapsWidget::onAddBank()
     if (!ok || name.isEmpty()) {
         return;
     }
-    Core()->cmd(QString("omb+ %1").arg(name));
+    name = Core()->sanitizeStringForCommand(name).replace('\n', '_').replace('\r', '_');
+    Core()->cmdRaw(QString("omb+ %1").arg(name));
     loadBanks();
 }
 


### PR DESCRIPTION
### Motivation
- MapsWidget previously constructed radare2 commands by concatenating untrusted bank names into `omb`/`omb+` calls, allowing command injection via separators like `;` or `!` from project-controlled bank names.
- The change aims to prevent executing injected r2 commands while preserving existing UI behavior (auto-select bank, create banks, and list maps).

### Description
- Store the numeric bank `id` in the `QComboBox` item data in `loadBanks()` and keep the display text as before to avoid using untrusted display text for commands (`src/widgets/MapsWidget.cpp`).
- Update `onBankChanged()` to read and validate the stored numeric `id` from item data and call `omb <id>` with that id instead of the combo text.
- Sanitize user-provided bank names in `onAddBank()` by calling `Core()->sanitizeStringForCommand(...)` and replacing newline/CR characters, and use `cmdRaw()` to execute the single-command `omb+ <name>` safely.
- Run `clang-format -i` on the modified file to ensure style consistency.

### Testing
- `clang-format -i src/widgets/MapsWidget.cpp` completed successfully in the environment.
- `./configure` was attempted and failed in this environment due to the missing `r2` dependency, so full build testing could not be performed.
- `make -j8 > /dev/null` was attempted and could not run because configuration did not complete, so no further automated build tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad40a5d848331ac04a7964addc986)