### PR TITLE
Sanitize structure offset values before executing aht

### DIFF
--- a/src/core/Iaito.cpp
+++ b/src/core/Iaito.cpp
@@ -438,7 +438,7 @@ bool IaitoCore::sdbSet(QString path, QString key, QString val)
 
 QString IaitoCore::sanitizeStringForCommand(QString s)
 {
-    static const QRegularExpression regexp(";|@`");
+    static const QRegularExpression regexp(QStringLiteral(R"([;|@`])"));
     return s.replace(regexp, QStringLiteral("_"));
 }
 
@@ -1060,7 +1060,7 @@ void IaitoCore::applyStructureOffset(const QString &structureOffset, RVA offset)
         offset = getOffset();
     }
 
-    this->cmdRawAt("aht " + structureOffset, offset);
+    this->cmdRawAt(QStringLiteral("aht ") + sanitizeStringForCommand(structureOffset), offset);
     emit instructionChanged(offset);
 }
 


### PR DESCRIPTION
### Motivation
- Prevent command injection when applying structure offsets because untrusted strings from radare2 output were concatenated into `aht` commands without filtering command separators.

### Description
- Hardened `IaitoCore::sanitizeStringForCommand()` to neutralize the `|` separator by switching the regular expression to `QStringLiteral(R"([;|@`])")` and replacing matches with `_`.
- Updated `IaitoCore::applyStructureOffset()` to call `sanitizeStringForCommand(structureOffset)` before composing the `aht` command so the value sent to `cmdRawAt` is sanitized.

### Testing
- Ran repository text searches to verify the updated usages of `sanitizeStringForCommand` and `applyStructureOffset` and confirmed the patched call site in `src/core/Iaito.cpp`.
- Attempted `make -j8` but it failed in this environment due to missing project configuration (`config.mk`), so a full build/test run could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aafe41e82083318726f3cdb9bf8ba1)