### PR TITLE
Avoid fixed /tmp path for rarun profile editing

### DIFF
--- a/src/widgets/DebugActions.cpp
+++ b/src/widgets/DebugActions.cpp
@@ -7,12 +7,14 @@
 #include "dialogs/NativeDebugDialog.h"
 
 #include <QDialogButtonBox>
+#include <QDir>
 #include <QFileInfo>
 #include <QList>
 #include <QMenu>
 #include <QPainter>
 #include <QPushButton>
 #include <QSettings>
+#include <QStandardPaths>
 #include <QTextEdit>
 #include <QToolBar>
 #include <QToolButton>
@@ -408,8 +410,13 @@ void DebugActions::editRarunProfile()
 {
     QString dbgProfile = Core()->getConfig("dbg.profile");
     if (dbgProfile.isEmpty()) {
-        // do not hardcode the default rarun2 profile filename
-        dbgProfile = QStringLiteral("/tmp/profile.r2.txt");
+        const QString configDir = QStandardPaths::writableLocation(QStandardPaths::AppConfigLocation);
+        if (!configDir.isEmpty()) {
+            QDir().mkpath(configDir);
+            dbgProfile = QDir(configDir).filePath(QStringLiteral("profile.r2.txt"));
+        } else {
+            dbgProfile = QDir::home().filePath(QStringLiteral(".iaito-profile.r2.txt"));
+        }
     }
     if (openTextEditDialogFromFile(dbgProfile)) {
         Core()->setConfig("dbg.profile", dbgProfile);


### PR DESCRIPTION
### Motivation
- Fix insecure temporary file usage where the rarun profile editor unconditionally read/wrote `/tmp/profile.r2.txt`, enabling symlink-based arbitrary file overwrite by local attackers.

### Description
- Replace the hard-coded `/tmp/profile.r2.txt` fallback in `DebugActions::editRarunProfile()` with a per-user path under `QStandardPaths::AppConfigLocation`.
- Create the config directory with `QDir().mkpath()` and fall back to `~/.iaito-profile.r2.txt` when the config location is unavailable.
- Add `#include <QDir>` and `#include <QStandardPaths>` and preserve the existing behavior of using `dbg.profile` when it is already configured.

### Testing
- Ran repository inspections and `git diff` to verify the patch was applied and localized to `DebugActions::editRarunProfile()`.
- Executed `./configure` which failed in this environment because `radare2`/`r2` is not installed, so a build/test run could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aad716a47c83319a0b787f7cdc8336)