### PR TITLE
Validate project names before executing project-related r2 commands

### DIFF
--- a/src/core/Iaito.cpp
+++ b/src/core/Iaito.cpp
@@ -2717,7 +2717,10 @@ QStringList IaitoCore::getProjectNames()
 
     QJsonArray jsonArray = cmdj("Pj").array();
     for (const QJsonValue value : jsonArray) {
-        ret.append(value.toString());
+        const QString projectName = value.toString();
+        if (isProjectNameValid(projectName)) {
+            ret.append(projectName);
+        }
     }
 
     return ret;
@@ -4307,6 +4310,11 @@ void IaitoCore::loadPDB(const QString &file)
 
 void IaitoCore::openProject(const QString &name)
 {
+    if (!isProjectNameValid(name)) {
+        QMessageBox::critical(nullptr, tr("Error"), tr("Invalid project name."));
+        return;
+    }
+
     bool ok = cmdRaw0(QStringLiteral("'P ") + name); //  + "@e:scr.interactive=false");
     if (ok) {
         notes = QString::fromUtf8(QByteArray::fromBase64(cmdRaw("Pnj").toUtf8()));
@@ -4321,6 +4329,12 @@ void IaitoCore::openProject(const QString &name)
 
 void IaitoCore::saveProject(const QString &name)
 {
+    if (!isProjectNameValid(name)) {
+        QMessageBox::critical(nullptr, tr("Error"), tr("Invalid project name."));
+        emit projectSaved(false, name);
+        return;
+    }
+
     Core()->setConfig("scr.interactive", false);
     const bool ok = cmdRaw0(QStringLiteral("'Ps ") + name.trimmed());
     if (!ok) {

--- a/src/core/MainWindow.cpp
+++ b/src/core/MainWindow.cpp
@@ -688,6 +688,11 @@ void MainWindow::displayInitialOptionsDialog(const InitialOptions &options, bool
 
 void MainWindow::openProject(const QString &project_name)
 {
+    if (!IaitoCore::isProjectNameValid(project_name)) {
+        QMessageBox::critical(this, tr("Error"), tr("Invalid project name."));
+        return;
+    }
+
     QString filename = core->cmdRaw("Pi " + project_name);
     setFilename(filename.trimmed());
 


### PR DESCRIPTION
### Motivation
- Prevent command injection by ensuring project names coming from disk or UI are validated before being concatenated into radare2 commands.
- The code previously consumed project names from `Pj` and passed them directly to `Pi`/`Po`/`Ps`, which allows an attacker to craft names with command separators to execute arbitrary r2 commands.

### Description
- Filter project list in `IaitoCore::getProjectNames()` to only return names that pass `isProjectNameValid()`, avoiding use of untrusted names from `Pj` (file: `src/core/Iaito.cpp`).
- Add validation guard in `IaitoCore::openProject()` to reject invalid names and avoid executing `'P ` when the name fails `isProjectNameValid()` (file: `src/core/Iaito.cpp`).
- Add validation guard in `IaitoCore::saveProject()` to reject invalid names before calling `'Ps ` and to emit `projectSaved(false, name)` on rejection (file: `src/core/Iaito.cpp`).
- Add validation guard in `MainWindow::openProject()` to stop invalid project names from being used with `Pi` and `openProject()` (file: `src/core/MainWindow.cpp`).

### Testing
- Ran `make -j8 > /dev/null`, which failed due to a missing generated `config.mk` in this environment (build not possible here). 
- Ran `./configure`, which failed in the container due to missing tooling/dependencies (notably `r2` and `pkg-config`).
- Performed local source validation via targeted edits and compilation attempts were not possible, but unit/functional behavior is preserved by only rejecting invalid project names using the existing `isProjectNameValid()` predicate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab287fe9008331a633137bca43a9da)