### PR TITLE
Fix debugger UI hangs: implement breakTask, prevent deadlocks on stop

### DIFF
--- a/src/common/AnalTask.cpp
+++ b/src/common/AnalTask.cpp
@@ -15,12 +15,7 @@ AnalTask::~AnalTask() {}
 void AnalTask::interrupt()
 {
     AsyncTask::interrupt();
-#if R2_VERSION_NUMBER >= 50909
-    RCore *core = Core()->core_;
-    core->cons->context->breaked = true;
-#else
-    r_cons_singleton()->context->breaked = true;
-#endif
+    Core()->setConsBreaked();
 }
 
 QString AnalTask::getTitle()

--- a/src/common/DecompileTask.cpp
+++ b/src/common/DecompileTask.cpp
@@ -19,16 +19,7 @@ void DecompileTask::interrupt()
 {
     loopInterrupted = true;
     AsyncTask::interrupt();
-#if R2_VERSION_NUMBER >= 50909
-    RCore *core = Core()->core_;
-    if (core && core->cons && core->cons->context) {
-        core->cons->context->breaked = true;
-    }
-#else
-    if (r_cons_singleton() && r_cons_singleton()->context) {
-        r_cons_singleton()->context->breaked = true;
-    }
-#endif
+    Core()->setConsBreaked();
     // Previously we raised SIGINT in-process here which can interrupt
     // Qt/libc allocations and lead to crashes. Instead rely on radare2's
     // break flag plus signaling child processes from AsyncTask::interrupt.

--- a/src/common/R2Task.cpp
+++ b/src/common/R2Task.cpp
@@ -72,8 +72,11 @@ void R2Task::startTask()
 
 void R2Task::breakTask()
 {
-    if (task) {
-        //        r_core_task_break(&Core()->core_->tasks, task->id);
+    if (task && task->core) {
+        // Set the console breaked flag so the running r2 command checks it
+        // and returns early.  Uses the same mechanism as the analysis
+        // progress dialog interrupt (see commit a0ce535).
+        Core()->setConsBreaked();
     }
 }
 

--- a/src/common/RunScriptTask.cpp
+++ b/src/common/RunScriptTask.cpp
@@ -11,12 +11,7 @@ RunScriptTask::~RunScriptTask() {}
 void RunScriptTask::interrupt()
 {
     AsyncTask::interrupt();
-#if R2_VERSION_NUMBER >= 50909
-    RCore *core = Core()->core_;
-    core->cons->context->breaked = true;
-#else
-    r_cons_singleton()->context->breaked = true;
-#endif
+    Core()->setConsBreaked();
 }
 
 void RunScriptTask::runTask()

--- a/src/core/Iaito.cpp
+++ b/src/core/Iaito.cpp
@@ -2052,7 +2052,9 @@ void IaitoCore::startEmulation()
     }
 
     // clear registers, init esil state, stack, progcounter at current seek
-    asyncCmd("aei; aeim; aeip", debugTask);
+    if (!asyncCmd("aei; aeim; aeip", debugTask)) {
+        return;
+    }
 
     emit debugTaskStateChanged();
 
@@ -2182,9 +2184,33 @@ void IaitoCore::attachDebug(int pid)
     debugTask->startTask();
 }
 
+void IaitoCore::setConsBreaked()
+{
+#if R2_VERSION_NUMBER >= 50909
+    if (core_ && core_->cons && core_->cons->context) {
+        core_->cons->context->breaked = true;
+    }
+#else
+    if (r_cons_singleton() && r_cons_singleton()->context) {
+        r_cons_singleton()->context->breaked = true;
+    }
+#endif
+}
+
 void IaitoCore::suspendDebug()
 {
-    debugTask->breakTask();
+    if (!debugTask.isNull()) {
+        debugTask->breakTask();
+        // r2 debug/analysis phases may clear the breaked flag via
+        // r_cons_break_push/pop cycles.  Keep re-setting it on a
+        // timer so the interrupt is never lost — same pattern as
+        // the analysis progress dialog (commit a0ce535).
+        interruptTimer.setInterval(100);
+        interruptTimer.setSingleShot(false);
+        connect(&interruptTimer, &QTimer::timeout, this,
+                &IaitoCore::setConsBreaked, Qt::UniqueConnection);
+        interruptTimer.start();
+    }
 }
 
 void IaitoCore::stopDebug()
@@ -2194,8 +2220,18 @@ void IaitoCore::stopDebug()
     }
 
     if (!debugTask.isNull()) {
+        // Interrupt the running task and wait for it to finish before
+        // issuing synchronous commands — otherwise CORE_LOCK() in cmd()
+        // deadlocks the UI thread against the still-running worker.
         suspendDebug();
+        debugTask->joinTask();
+        debugTask.clear();
     }
+
+    // Stop the interrupt timer and clear stale breaked state so they
+    // don't leak into cleanup commands
+    interruptTimer.stop();
+    r_cons_break_clear(core_->cons);
 
     currentlyDebugging = false;
     emit debugTaskStateChanged();
@@ -2257,6 +2293,8 @@ void IaitoCore::continueDebug()
     emit debugTaskStateChanged();
     connect(debugTask.data(), &R2Task::finished, this, [this]() {
         debugTask.clear();
+        interruptTimer.stop();
+        r_cons_break_clear(core_->cons);
         syncAndSeekProgramCounter();
         emit registersChanged();
         emit refreshCodeViews();
@@ -2285,6 +2323,8 @@ void IaitoCore::continueUntilDebug(QString offset)
     emit debugTaskStateChanged();
     connect(debugTask.data(), &R2Task::finished, this, [this]() {
         debugTask.clear();
+        interruptTimer.stop();
+        r_cons_break_clear(core_->cons);
         syncAndSeekProgramCounter();
         emit registersChanged();
         emit stackChanged();
@@ -2314,6 +2354,8 @@ void IaitoCore::continueUntilCall()
     emit debugTaskStateChanged();
     connect(debugTask.data(), &R2Task::finished, this, [this]() {
         debugTask.clear();
+        interruptTimer.stop();
+        r_cons_break_clear(core_->cons);
         syncAndSeekProgramCounter();
         emit debugTaskStateChanged();
     });
@@ -2340,6 +2382,8 @@ void IaitoCore::continueUntilSyscall()
     emit debugTaskStateChanged();
     connect(debugTask.data(), &R2Task::finished, this, [this]() {
         debugTask.clear();
+        interruptTimer.stop();
+        r_cons_break_clear(core_->cons);
         syncAndSeekProgramCounter();
         emit debugTaskStateChanged();
     });
@@ -2366,6 +2410,8 @@ void IaitoCore::stepDebug()
     emit debugTaskStateChanged();
     connect(debugTask.data(), &R2Task::finished, this, [this]() {
         debugTask.clear();
+        interruptTimer.stop();
+        r_cons_break_clear(core_->cons);
         syncAndSeekProgramCounter();
         emit debugTaskStateChanged();
     });
@@ -2392,6 +2438,8 @@ void IaitoCore::stepOverDebug()
     emit debugTaskStateChanged();
     connect(debugTask.data(), &R2Task::finished, this, [this]() {
         debugTask.clear();
+        interruptTimer.stop();
+        r_cons_break_clear(core_->cons);
         syncAndSeekProgramCounter();
         emit debugTaskStateChanged();
     });
@@ -2405,13 +2453,16 @@ void IaitoCore::stepOutDebug()
         return;
     }
 
-    emit debugTaskStateChanged();
     if (!asyncCmd("dsf", debugTask)) {
         return;
     }
 
+    emit debugTaskStateChanged();
+
     connect(debugTask.data(), &R2Task::finished, this, [this]() {
         debugTask.clear();
+        interruptTimer.stop();
+        r_cons_break_clear(core_->cons);
         syncAndSeekProgramCounter();
         emit debugTaskStateChanged();
     });

--- a/src/core/Iaito.h
+++ b/src/core/Iaito.h
@@ -17,6 +17,7 @@
 #include <QMutex>
 #include <QObject>
 #include <QStringList>
+#include <QTimer>
 
 class AsyncTaskManager;
 class BasicInstructionHighlighter;
@@ -455,6 +456,12 @@ public:
     void attachDebug(int pid);
     void stopDebug();
     void suspendDebug();
+    /**
+     * @brief Set r_cons breaked flag to interrupt a running r2 command.
+     * Shared interrupt mechanism used by debugger suspend, analysis interrupt,
+     * and R2TaskDialog cancel (see commit a0ce535).
+     */
+    void setConsBreaked();
     void syncAndSeekProgramCounter();
     void continueDebug();
     void continueUntilCall();
@@ -813,6 +820,14 @@ private:
 
     QSharedPointer<R2Task> debugTask;
     R2TaskDialog *debugTaskDialog;
+
+    /**
+     * @brief Repeatedly set the r_cons breaked flag so that a running r2
+     * command (debug continue, analysis, etc.) notices the interrupt even
+     * across r_cons_break_push/pop cycles.  Mirrors the pattern used by
+     * the analysis progress dialog (commit a0ce535).
+     */
+    QTimer interruptTimer;
 
     QVector<QString> getIaitoRCFilePaths(int n) const;
 };

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -483,10 +483,10 @@ void InitialOptionsDialog::setupAndStartAnalysis(
     interruptTimer.setInterval(100);
     interruptTimer.setSingleShot(false);
     QObject::connect(&interruptTimer, &QTimer::timeout, &progressDialog, [&]() {
-        rcore->cons->context->breaked = true;
+        iaito->setConsBreaked();
     });
     QObject::connect(&interruptBtn, &QPushButton::clicked, &progressDialog, [&]() {
-        rcore->cons->context->breaked = true;
+        iaito->setConsBreaked();
         interrupted = true;
         interruptTimer.start();
         interruptBtn.setEnabled(false);


### PR DESCRIPTION
The debugger UI would hang/deadlock in several scenarios:

1. breakTask() was a no-op (body commented out), so suspendDebug() and
   the "Suspend" button did nothing. Clicking suspend or stop while a
   debug continue (dc) was running left the UI frozen.

2. stopDebug() called synchronous cmd()/cmdEsil() on the UI thread
   without waiting for the running debug task to finish, causing a
   CORE_LOCK() deadlock against the still-running worker thread.

3. startEmulation() didn't check asyncCmd() return value, leading to
   null pointer dereference if a task was already running.

4. stepOutDebug() emitted debugTaskStateChanged before creating the
   task, signaling incorrect state to the toolbar.

5. Stale r_cons breaked state leaked between debug operations, causing
   subsequent commands to abort immediately.

Fixes applied:
- Implement breakTask() to set cons->context->breaked, matching the
  pattern from the analysis dialog interrupt (commit a0ce535)
- Add setConsBreaked() as shared API, consolidating 4 duplicate
  implementations (AnalTask, RunScriptTask, DecompileTask, R2Task)
- Add interrupt timer in suspendDebug() that repeatedly re-sets the
  breaked flag across r_cons_break_push/pop cycles
- stopDebug() now joins the running task before issuing sync commands
- Clear breaked state + stop timer after every debug task completion
- Guard startEmulation() asyncCmd return value
- Fix stepOutDebug signal ordering

https://claude.ai/code/session_018WSHRh9CNu8boE3Jz5P1mf