### PR TITLE
Fix stopDebug() hang: replace blocking joinTask() with async cleanup

### DIFF
--- a/src/core/Iaito.cpp
+++ b/src/core/Iaito.cpp
@@ -2220,14 +2220,34 @@ void IaitoCore::stopDebug()
     }
 
     if (!debugTask.isNull()) {
-        // Interrupt the running task and wait for it to finish before
-        // issuing synchronous commands — otherwise CORE_LOCK() in cmd()
-        // deadlocks the UI thread against the still-running worker.
+        // Disconnect previous finished handlers from debug operations
+        // (continue, step, etc.) since we are taking over cleanup.
+        disconnect(debugTask.data(), &R2Task::finished, this, nullptr);
+
+        // The R2TaskDialog (if any) will auto-close via its own finished
+        // connection and WA_DeleteOnClose.  Clear our pointer so we don't
+        // hold a dangling reference.
+        debugTaskDialog = nullptr;
+
+        // Interrupt the running task.  suspendDebug() sets the breaked flag
+        // and starts a timer to keep re-setting it — r2 may clear it via
+        // r_cons_break_push/pop cycles.  We must NOT block the main thread
+        // with joinTask() because that prevents the timer from firing,
+        // which can cause an indefinite hang.
         suspendDebug();
-        debugTask->joinTask();
-        debugTask.clear();
+
+        connect(debugTask.data(), &R2Task::finished, this, [this]() {
+            debugTask.clear();
+            finishStopDebug();
+        });
+        return;
     }
 
+    finishStopDebug();
+}
+
+void IaitoCore::finishStopDebug()
+{
     // Stop the interrupt timer and clear stale breaked state so they
     // don't leak into cleanup commands
     interruptTimer.stop();

--- a/src/core/Iaito.h
+++ b/src/core/Iaito.h
@@ -456,6 +456,9 @@ public:
     void attachDebug(int pid);
     void stopDebug();
     void suspendDebug();
+private:
+    void finishStopDebug();
+public:
     /**
      * @brief Set r_cons breaked flag to interrupt a running r2 command.
      * Shared interrupt mechanism used by debugger suspend, analysis interrupt,


### PR DESCRIPTION
stopDebug() called joinTask() on the main/GUI thread, which blocked
the event loop. This prevented the interruptTimer from firing, so if
r2 cleared the breaked flag via r_cons_break_push/pop cycles before
the worker checked it, the interrupt was permanently lost and the UI
froze indefinitely.

Replace the synchronous joinTask() with an async pattern: disconnect
existing finished handlers, call suspendDebug() (which keeps
re-setting the breaked flag on a timer), and connect a new finished
handler that performs the cleanup once the task actually stops.

https://claude.ai/code/session_017oLLd1cJiidCQFHqzwAv7Z