### PR TITLE
Fix CI: replace abandoned ilammy/msvc-dev-cmd with TheMrMilchmann/setup-msvc-dev

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,7 +217,7 @@ jobs:
         submodules: false
         persist-credentials: false
     - name: Preparing msvc toolchain
-      uses: ilammy/msvc-dev-cmd@v1
+      uses: TheMrMilchmann/setup-msvc-dev@v4
       with:
         arch: x64
     - name: install Qt


### PR DESCRIPTION
The ilammy/msvc-dev-cmd action is no longer maintained and still runs on
Node.js 20, which triggers a deprecation warning on GitHub Actions runners.
Switch to TheMrMilchmann/setup-msvc-dev@v4 which is actively maintained.

https://claude.ai/code/session_014EvATVvGJpAM1Ku9urFF1x