### PR TITLE
Add support for user-defined interface themes

### DIFF
--- a/src/Iaito.pro
+++ b/src/Iaito.pro
@@ -298,6 +298,7 @@ SOURCES += \
     widgets/ColorThemeComboBox.cpp \
     widgets/ColorThemeListView.cpp \
     dialogs/settings/ColorThemeEditDialog.cpp \
+    dialogs/settings/InterfaceThemeEditDialog.cpp \
     widgets/MemoryDockWidget.cpp \
     common/CrashHandler.cpp \
     common/BugReporting.cpp \
@@ -494,6 +495,7 @@ HEADERS  += \
     widgets/MemoryDockWidget.h \
     widgets/ColorThemeListView.h \
     dialogs/settings/ColorThemeEditDialog.h \
+    dialogs/settings/InterfaceThemeEditDialog.h \
     dialogs/settings/KeyboardOptionsWidget.h \
     dialogs/LinkTypeDialog.h \
     common/BugReporting.h \
@@ -621,7 +623,8 @@ RESOURCES += \
     themes/qdarkstyle/dark.qrc \
     themes/midnight/midnight.qrc \
     themes/lightstyle/light.qrc \
-    themes/classic/classic.qrc
+    themes/classic/classic.qrc \
+    themes/template/template.qrc
 
 
 DISTFILES += Iaito.astylerc

--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -4,10 +4,14 @@
 #include <QDir>
 #include <QEvent>
 #include <QFile>
+#include <QFileInfo>
 #include <QFontDatabase>
 #include <QJsonArray>
 #include <QJsonObject>
+#include <QLineEdit>
 #include <QPlainTextEdit>
+#include <QPushButton>
+#include <QStandardPaths>
 #include <QStyle>
 #include <QTextEdit>
 #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
@@ -409,29 +413,6 @@ static void applyFontEverywhere(const QFont &font)
     }
 }
 
-static void setDarkPalette(
-    QPalette &palette,
-    const QColor &window,
-    const QColor &base,
-    const QColor &alternateBase,
-    const QColor &highlight)
-{
-    const QColor text(0xef, 0xf0, 0xf1);
-    palette.setColor(QPalette::Window, window);
-    palette.setColor(QPalette::WindowText, text);
-    palette.setColor(QPalette::Base, base);
-    palette.setColor(QPalette::AlternateBase, alternateBase);
-    palette.setColor(QPalette::Text, text);
-    palette.setColor(QPalette::Button, window);
-    palette.setColor(QPalette::ButtonText, text);
-    palette.setColor(QPalette::Highlight, highlight);
-    palette.setColor(QPalette::HighlightedText, text);
-    palette.setColor(QPalette::ToolTipBase, QColor(0x5a, 0x75, 0x66));
-    palette.setColor(QPalette::ToolTipText, Qt::white);
-    palette.setColor(QPalette::Disabled, QPalette::Text, QColor(0x45, 0x45, 0x45));
-    palette.setColor(QPalette::Disabled, QPalette::ButtonText, QColor(0x45, 0x45, 0x45));
-}
-
 void Configuration::loadNativeStylesheet()
 {
     /* Load Qt Theme */
@@ -498,12 +479,7 @@ void Configuration::loadDarkStylesheet()
                       "}";
 #endif
         QPalette p = qApp->palette();
-        setDarkPalette(
-            p,
-            QColor(0x31, 0x36, 0x3b),
-            QColor(0x23, 0x26, 0x29),
-            QColor(0x31, 0x36, 0x3b),
-            QColor(0x3d, 0xae, 0xe9));
+        p.setColor(QPalette::Text, Qt::white);
         qApp->setPalette(p);
         applyFontEverywhere(defaultAppFont);
         qApp->setStyleSheet(stylesheet);
@@ -521,12 +497,7 @@ void Configuration::loadMidnightStylesheet()
         QString stylesheet = ts.readAll();
 
         QPalette p = qApp->palette();
-        setDarkPalette(
-            p,
-            QColor(0x1f, 0x20, 0x22),
-            QColor(0x23, 0x26, 0x29),
-            QColor(0x1f, 0x20, 0x22),
-            QColor(0x36, 0x39, 0x3c));
+        p.setColor(QPalette::Text, Qt::white);
         qApp->setPalette(p);
 
         qApp->setFont(defaultAppFont);
@@ -587,6 +558,135 @@ void Configuration::loadClassicStylesheet()
         }
         emit fontsUpdated();
     }
+}
+
+QString Configuration::userThemesDir()
+{
+    const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
+        + QDir::separator() + QStringLiteral("themes");
+    QDir().mkpath(dir);
+    return dir;
+}
+
+bool Configuration::isCustomInterfaceTheme(const QString &name)
+{
+    return QFileInfo::exists(QDir(userThemesDir()).filePath(name + QStringLiteral(".theme")));
+}
+
+bool Configuration::isValidThemeName(const QString &name)
+{
+    return r_name_check(name.toUtf8().constData());
+}
+
+const QStringList &Configuration::interfaceThemeVariableKeys()
+{
+    static const QStringList keys = {
+        "background",
+        "panel",
+        "surface",
+        "border",
+        "text",
+        "mutedText",
+        "accent",
+        "accentText",
+        "navbarCode",
+        "navbarString",
+        "navbarSymbol"};
+    return keys;
+}
+
+QHash<QString, QColor> Configuration::defaultInterfaceThemeVariables()
+{
+    QWidget base;
+    QLineEdit edit;
+    QPushButton button;
+    base.ensurePolished();
+    edit.ensurePolished();
+    button.ensurePolished();
+    const QPalette &bp = base.palette();
+    return {
+        {"background", bp.color(QPalette::Window)},
+        {"panel", edit.palette().color(QPalette::Base)},
+        {"surface", button.palette().color(QPalette::Button)},
+        {"border", bp.color(QPalette::Midlight)},
+        {"text", bp.color(QPalette::WindowText)},
+        {"mutedText", bp.color(QPalette::Disabled, QPalette::WindowText)},
+        {"accent", bp.color(QPalette::Highlight)},
+        {"accentText", bp.color(QPalette::HighlightedText)},
+        {"navbarCode", QColor(0x82, 0xa8, 0x6f)},
+        {"navbarString", QColor(0x6f, 0x86, 0xd8)},
+        {"navbarSymbol", QColor(0xdd, 0xa3, 0x68)}};
+}
+
+QHash<QString, QColor> Configuration::loadInterfaceThemeVariables(const QString &name)
+{
+    QHash<QString, QColor> vars = defaultInterfaceThemeVariables();
+    QSettings theme(
+        QDir(userThemesDir()).filePath(name + QStringLiteral(".theme")), QSettings::IniFormat);
+    for (const QString &key : interfaceThemeVariableKeys()) {
+        const QColor color(theme.value(key).toString());
+        if (color.isValid()) {
+            vars[key] = color;
+        }
+    }
+    return vars;
+}
+
+void Configuration::saveInterfaceThemeVariables(
+    const QString &name, const QHash<QString, QColor> &vars)
+{
+    QSettings theme(
+        QDir(userThemesDir()).filePath(name + QStringLiteral(".theme")), QSettings::IniFormat);
+    for (const QString &key : interfaceThemeVariableKeys()) {
+        theme.setValue(key, vars.value(key).name());
+    }
+}
+
+QString Configuration::buildInterfaceStyleSheet(const QHash<QString, QColor> &vars)
+{
+    QFile f(QStringLiteral(":/template/interface-template.qss"));
+    if (!f.open(QFile::ReadOnly | QFile::Text)) {
+        return QString();
+    }
+    QString qss = QTextStream(&f).readAll();
+    for (const QString &key : interfaceThemeVariableKeys()) {
+        qss.replace(QStringLiteral("{{") + key + QStringLiteral("}}"), vars.value(key).name());
+    }
+    return qss;
+}
+
+void Configuration::applyInterfaceVariables(const QHash<QString, QColor> &vars)
+{
+    setColor("navbarCode", vars.value("navbarCode"));
+    setColor("navbarString", vars.value("navbarString"));
+    setColor("navbarSymbol", vars.value("navbarSymbol"));
+    setColor("background", vars.value("background"));
+    QPalette p = qApp->palette();
+    p.setColor(QPalette::Window, vars.value("background"));
+    p.setColor(QPalette::WindowText, vars.value("text"));
+    p.setColor(QPalette::Base, vars.value("panel"));
+    p.setColor(QPalette::Text, vars.value("text"));
+    p.setColor(QPalette::AlternateBase, vars.value("panel"));
+    p.setColor(QPalette::Button, vars.value("surface"));
+    p.setColor(QPalette::ButtonText, vars.value("text"));
+    p.setColor(QPalette::Highlight, vars.value("accent"));
+    p.setColor(QPalette::HighlightedText, vars.value("accentText"));
+    p.setColor(QPalette::ToolTipBase, vars.value("surface"));
+    p.setColor(QPalette::ToolTipText, vars.value("text"));
+    p.setColor(QPalette::PlaceholderText, vars.value("mutedText"));
+    p.setColor(QPalette::Disabled, QPalette::Text, vars.value("mutedText"));
+    qApp->setPalette(p);
+    applyFontEverywhere(defaultAppFont);
+    qApp->setStyleSheet(buildInterfaceStyleSheet(vars));
+}
+
+bool Configuration::loadUserStylesheet(const QString &name)
+{
+    if (!isCustomInterfaceTheme(name)) {
+        return false;
+    }
+    applyInterfaceVariables(loadInterfaceThemeVariables(name));
+    return true;
 }
 
 const QFont Configuration::getBaseFont() const
@@ -737,7 +837,7 @@ void Configuration::setInterfaceTheme(int theme)
         loadLightStylesheet();
     } else if (interfaceTheme.name == "Classic") {
         loadClassicStylesheet();
-    } else {
+    } else if (!loadUserStylesheet(interfaceTheme.name)) {
         loadNativeStylesheet();
     }
 
@@ -927,15 +1027,18 @@ void Configuration::applySavedAsmOptions()
 
 const QList<IaitoInterfaceTheme> &Configuration::iaitoInterfaceThemesList()
 {
-    // Cached once, but the Native entry's darkness flag is refreshed on
-    // every access so that live OS theme changes are reflected immediately.
-    static QList<IaitoInterfaceTheme> list
-        = {{"Native", Configuration::nativeWindowIsDark() ? DarkFlag : LightFlag},
-           {"Dark", DarkFlag},
-           {"Midnight", DarkFlag},
-           {"Light", LightFlag},
-           {"Classic", LightFlag}};
-    list[0].flag = Configuration::nativeWindowIsDark() ? DarkFlag : LightFlag;
+    static QList<IaitoInterfaceTheme> list;
+    list = {{"Native", Configuration::nativeWindowIsDark() ? DarkFlag : LightFlag},
+            {"Dark", DarkFlag},
+            {"Midnight", DarkFlag},
+            {"Light", LightFlag},
+            {"Classic", LightFlag}};
+    const auto userThemes = QDir(userThemesDir())
+                                .entryInfoList(
+                                    QStringList{QStringLiteral("*.theme")}, QDir::Files, QDir::Name);
+    for (const QFileInfo &fi : userThemes) {
+        list.append({fi.completeBaseName(), DarkFlag});
+    }
     return list;
 }
 

--- a/src/common/Configuration.h
+++ b/src/common/Configuration.h
@@ -62,6 +62,7 @@ private:
     void loadDarkStylesheet();
     void loadMidnightStylesheet();
     void loadClassicStylesheet();
+    bool loadUserStylesheet(const QString &name);
 
     void onSystemColorSchemeChanged();
 
@@ -73,6 +74,15 @@ protected:
 
 public:
     static const QList<IaitoInterfaceTheme> &iaitoInterfaceThemesList();
+    static QString userThemesDir();
+    static bool isCustomInterfaceTheme(const QString &name);
+    static bool isValidThemeName(const QString &name);
+    static const QStringList &interfaceThemeVariableKeys();
+    static QHash<QString, QColor> defaultInterfaceThemeVariables();
+    static QHash<QString, QColor> loadInterfaceThemeVariables(const QString &name);
+    static void saveInterfaceThemeVariables(const QString &name, const QHash<QString, QColor> &vars);
+    static QString buildInterfaceStyleSheet(const QHash<QString, QColor> &vars);
+    void applyInterfaceVariables(const QHash<QString, QColor> &vars);
     static const QHash<QString, ColorFlags> relevantThemes;
     static const QHash<QString, QHash<ColorFlags, QColor>> iaitoOptionColors;
 

--- a/src/dialogs/InitialOptionsDialog.cpp
+++ b/src/dialogs/InitialOptionsDialog.cpp
@@ -452,7 +452,6 @@ void InitialOptionsDialog::setupAndStartAnalysis()
     QPlainTextEdit logText;
     logText.setReadOnly(true);
     qhelpers::bindFont(&logText, false, true);
-    logText.setStyleSheet("QPlainTextEdit { background-color: #1a1a1a; color: #cccccc; }");
     layout.addWidget(&logText);
 
     QPushButton interruptBtn(tr("Interrupt"));

--- a/src/dialogs/settings/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/settings/AppearanceOptionsWidget.cpp
@@ -6,6 +6,7 @@
 #include <QLabel>
 #include <QPainter>
 #include <QSignalBlocker>
+#include <QSettings>
 #include <QStandardPaths>
 #include <QTranslator>
 #include <QtSvg/QSvgRenderer>
@@ -22,7 +23,9 @@
 #include "common/ColorThemeWorker.h"
 #include "core/MainWindow.h"
 #include "dialogs/settings/ColorThemeEditDialog.h"
+#include "dialogs/settings/InterfaceThemeEditDialog.h"
 #include "widgets/ColorPicker.h"
+#include <QPushButton>
 
 namespace {
 struct FontFamilyEntry
@@ -42,6 +45,16 @@ static const FontFamilyEntry kFontFamilies[] = {
 static const char *kCustomLabel = "Custom...";
 static const char *kDefaultFamily = "IBM Plex Mono";
 static const int kDefaultPointSize = 13;
+
+static bool interfaceThemeExists(const QString &name)
+{
+    for (const auto &theme : Configuration::iaitoInterfaceThemesList()) {
+        if (theme.name == name) {
+            return true;
+        }
+    }
+    return false;
+}
 } // namespace
 
 AppearanceOptionsWidget::AppearanceOptionsWidget(SettingsDialog *dialog)
@@ -49,6 +62,7 @@ AppearanceOptionsWidget::AppearanceOptionsWidget(SettingsDialog *dialog)
     , ui(new Ui::AppearanceOptionsWidget)
 {
     ui->setupUi(this);
+
     for (const auto &entry : kFontFamilies) {
         ui->fontFamilyComboBox
             ->addItem(QString::fromLatin1(entry.label), QString::fromLatin1(entry.family));
@@ -88,6 +102,12 @@ AppearanceOptionsWidget::AppearanceOptionsWidget(SettingsDialog *dialog)
         ui->importButton->setIcon(getIconFromSvg(":/img/icons/download_black.svg", textColor));
         ui->exportButton->setIcon(getIconFromSvg(":/img/icons/upload_black.svg", textColor));
         ui->renameButton->setIcon(getIconFromSvg(":/img/icons/rename.svg", textColor));
+        ui->ifaceEditButton->setIcon(getIconFromSvg(":/img/icons/pencil_thin.svg", textColor));
+        ui->ifaceRenameButton->setIcon(getIconFromSvg(":/img/icons/rename.svg", textColor));
+        ui->ifaceCopyButton->setIcon(getIconFromSvg(":/img/icons/copy.svg", textColor));
+        ui->ifaceDeleteButton->setIcon(getIconFromSvg(":/img/icons/trash_bin.svg", textColor));
+        ui->ifaceExportButton->setIcon(getIconFromSvg(":/img/icons/upload_black.svg", textColor));
+        ui->ifaceImportButton->setIcon(getIconFromSvg(":/img/icons/download_black.svg", textColor));
     };
     setIcons();
     connect(Config(), &Configuration::interfaceThemeChanged, this, setIcons);
@@ -204,6 +224,7 @@ void AppearanceOptionsWidget::updateThemeFromConfig(bool interfaceThemeChanged)
         Config()->setInterfaceTheme(currInterfaceThemeIndex);
     }
     ui->themeComboBox->setCurrentIndex(currInterfaceThemeIndex);
+    updateInterfaceModificationButtons(ui->themeComboBox->currentText());
     ui->colorComboBox->updateFromConfig(interfaceThemeChanged);
     updateModificationButtons(ui->colorComboBox->currentText());
 }
@@ -301,6 +322,163 @@ void AppearanceOptionsWidget::on_editButton_clicked()
     dial.setWindowTitle(tr("Theme Editor - <%1>").arg(ui->colorComboBox->currentText()));
     dial.exec();
     ui->colorComboBox->updateFromConfig(false);
+}
+
+void AppearanceOptionsWidget::selectInterfaceThemeByName(const QString &name)
+{
+    const auto &themes = Configuration::iaitoInterfaceThemesList();
+    for (int i = 0; i < themes.size(); ++i) {
+        if (themes[i].name == name) {
+            Config()->setInterfaceTheme(i);
+            break;
+        }
+    }
+    updateThemeFromConfig(false);
+}
+
+void AppearanceOptionsWidget::on_ifaceEditButton_clicked()
+{
+    InterfaceThemeEditDialog dialog(ui->themeComboBox->currentText(), this);
+    if (dialog.exec() == QDialog::Accepted) {
+        selectInterfaceThemeByName(dialog.savedName());
+    }
+}
+
+void AppearanceOptionsWidget::on_ifaceCopyButton_clicked()
+{
+    const QString current = ui->themeComboBox->currentText();
+
+    QString newName;
+    do {
+        newName = QInputDialog::getText(
+                      this,
+                      tr("Enter theme name"),
+                      tr("Name:"),
+                      QLineEdit::Normal,
+                      current + tr(" - copy"))
+                      .trimmed();
+        if (newName.isEmpty()) {
+            return;
+        }
+        if (!Configuration::isValidThemeName(newName)) {
+            QMessageBox::warning(this, tr("Theme Copy"), tr("Invalid theme name."));
+        } else if (interfaceThemeExists(newName)) {
+            QMessageBox::information(
+                this, tr("Theme Copy"), tr("Theme named %1 already exists.").arg(newName));
+        } else {
+            break;
+        }
+    } while (true);
+
+    if (Configuration::isCustomInterfaceTheme(current)) {
+        QFile::copy(
+            QDir(Configuration::userThemesDir()).filePath(current + QStringLiteral(".theme")),
+            QDir(Configuration::userThemesDir()).filePath(newName + QStringLiteral(".theme")));
+    } else {
+        Configuration::saveInterfaceThemeVariables(
+            newName, Configuration::defaultInterfaceThemeVariables());
+    }
+    selectInterfaceThemeByName(newName);
+}
+
+void AppearanceOptionsWidget::on_ifaceRenameButton_clicked()
+{
+    const QString current = ui->themeComboBox->currentText();
+    if (!Configuration::isCustomInterfaceTheme(current)) {
+        return;
+    }
+    const QString newName
+        = QInputDialog::getText(
+              this, tr("Enter new theme name"), tr("Name:"), QLineEdit::Normal, current)
+              .trimmed();
+    if (newName.isEmpty() || newName == current) {
+        return;
+    }
+    if (!Configuration::isValidThemeName(newName)) {
+        QMessageBox::critical(this, tr("Error"), tr("Invalid theme name."));
+        return;
+    }
+    if (interfaceThemeExists(newName)) {
+        QMessageBox::critical(this, tr("Error"), tr("Theme named %1 already exists.").arg(newName));
+        return;
+    }
+    QDir dir(Configuration::userThemesDir());
+    QFile::rename(
+        dir.filePath(current + QStringLiteral(".theme")),
+        dir.filePath(newName + QStringLiteral(".theme")));
+    selectInterfaceThemeByName(newName);
+}
+
+void AppearanceOptionsWidget::on_ifaceDeleteButton_clicked()
+{
+    const QString current = ui->themeComboBox->currentText();
+    if (!Configuration::isCustomInterfaceTheme(current)) {
+        return;
+    }
+    int ret = QMessageBox::question(
+        this, tr("Delete"), tr("Are you sure you want to delete <b>%1</b>?").arg(current));
+    if (ret != QMessageBox::Yes) {
+        return;
+    }
+    QFile::remove(QDir(Configuration::userThemesDir()).filePath(current + QStringLiteral(".theme")));
+    Config()->setInterfaceTheme(0);
+    updateThemeFromConfig(false);
+}
+
+void AppearanceOptionsWidget::on_ifaceExportButton_clicked()
+{
+    const QString current = ui->themeComboBox->currentText();
+    QString file = QFileDialog::getSaveFileName(
+        this,
+        "",
+        QStandardPaths::writableLocation(QStandardPaths::HomeLocation) + QDir::separator() + current
+            + QStringLiteral(".theme"));
+    if (file.isEmpty()) {
+        return;
+    }
+    const QHash<QString, QColor> vars = Configuration::isCustomInterfaceTheme(current)
+        ? Configuration::loadInterfaceThemeVariables(current)
+        : Configuration::defaultInterfaceThemeVariables();
+    QSettings out(file, QSettings::IniFormat);
+    for (const QString &key : Configuration::interfaceThemeVariableKeys()) {
+        out.setValue(key, vars.value(key).name());
+    }
+    out.sync();
+    if (out.status() != QSettings::NoError) {
+        QMessageBox::critical(this, tr("Error"), tr("Cannot write file."));
+    }
+}
+
+void AppearanceOptionsWidget::on_ifaceImportButton_clicked()
+{
+    QString fileName = QFileDialog::getOpenFileName(
+        this,
+        "",
+        QStandardPaths::writableLocation(QStandardPaths::HomeLocation),
+        tr("Interface theme (*.theme)"),
+        nullptr,
+        QFILEDIALOG_FLAGS);
+    if (fileName.isEmpty()) {
+        return;
+    }
+    const QString name = QFileInfo(fileName).completeBaseName();
+    const QString dst = QDir(Configuration::userThemesDir()).filePath(name + QStringLiteral(".theme"));
+    if (QFileInfo::exists(dst)) {
+        QFile::remove(dst);
+    }
+    if (!QFile::copy(fileName, dst)) {
+        QMessageBox::critical(this, tr("Error"), tr("Cannot import theme."));
+        return;
+    }
+    selectInterfaceThemeByName(name);
+}
+
+void AppearanceOptionsWidget::updateInterfaceModificationButtons(const QString &theme)
+{
+    bool editable = Configuration::isCustomInterfaceTheme(theme);
+    ui->ifaceEditButton->setEnabled(editable);
+    ui->ifaceRenameButton->setEnabled(editable);
+    ui->ifaceDeleteButton->setEnabled(editable);
 }
 
 void AppearanceOptionsWidget::on_copyButton_clicked()

--- a/src/dialogs/settings/AppearanceOptionsWidget.h
+++ b/src/dialogs/settings/AppearanceOptionsWidget.h
@@ -59,10 +59,20 @@ private slots:
      */
     void on_renameButton_clicked();
     void on_editButton_clicked();
+
+    void on_ifaceEditButton_clicked();
+    void on_ifaceCopyButton_clicked();
+    void on_ifaceRenameButton_clicked();
+    void on_ifaceDeleteButton_clicked();
+    void on_ifaceExportButton_clicked();
+    void on_ifaceImportButton_clicked();
+
     void onLanguageComboBoxCurrentIndexChanged(int index);
 
 private:
     void updateModificationButtons(const QString &theme);
+    void updateInterfaceModificationButtons(const QString &theme);
+    void selectInterfaceThemeByName(const QString &name);
     void updateFromConfig();
 
     /**

--- a/src/dialogs/settings/AppearanceOptionsWidget.ui
+++ b/src/dialogs/settings/AppearanceOptionsWidget.ui
@@ -171,24 +171,115 @@
       </widget>
      </item>
      <item row="2" column="1">
-      <widget class="QComboBox" name="themeComboBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
+      <layout class="QHBoxLayout" name="interfaceThemeLayout">
        <item>
-        <property name="text">
-         <string>Default</string>
-        </property>
+        <widget class="QComboBox" name="themeComboBox">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
        </item>
        <item>
-        <property name="text">
-         <string>Dark</string>
-        </property>
+        <widget class="QPushButton" name="ifaceEditButton">
+         <property name="toolTip">
+          <string>Edit Theme</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../resources.qrc">
+           <normaloff>:/img/icons/pencil_thin.svg</normaloff>:/img/icons/pencil_thin.svg</iconset>
+         </property>
+        </widget>
        </item>
-      </widget>
+       <item>
+        <widget class="QPushButton" name="ifaceRenameButton">
+         <property name="toolTip">
+          <string>Rename</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../resources.qrc">
+           <normaloff>:/img/icons/rename.svg</normaloff>:/img/icons/rename.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="ifaceCopyButton">
+         <property name="toolTip">
+          <string>Copy</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../resources.qrc">
+           <normaloff>:/img/icons/copy.svg</normaloff>:/img/icons/copy.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="ifaceDeleteButton">
+         <property name="toolTip">
+          <string>Delete</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../resources.qrc">
+           <normaloff>:/img/icons/trash_bin.svg</normaloff>:/img/icons/trash_bin.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="ifaceExportButton">
+         <property name="toolTip">
+          <string>Export</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../resources.qrc">
+           <normaloff>:/img/icons/upload_black.svg</normaloff>:/img/icons/upload_black.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="ifaceImportButton">
+         <property name="toolTip">
+          <string>Import</string>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="icon">
+          <iconset resource="../../resources.qrc">
+           <normaloff>:/img/icons/download_black.svg</normaloff>:/img/icons/download_black.svg</iconset>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="interfaceThemeSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
      </item>
      <item row="3" column="0">
       <widget class="QLabel" name="visualNavbarLabel">

--- a/src/dialogs/settings/InterfaceThemeEditDialog.cpp
+++ b/src/dialogs/settings/InterfaceThemeEditDialog.cpp
@@ -1,0 +1,110 @@
+#include "InterfaceThemeEditDialog.h"
+
+#include "common/Configuration.h"
+#include "widgets/ColorPicker.h"
+#include "widgets/ColorThemeListView.h"
+
+#include <QApplication>
+#include <QDialogButtonBox>
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QMessageBox>
+#include <QTimer>
+#include <QVBoxLayout>
+
+InterfaceThemeEditDialog::InterfaceThemeEditDialog(const QString &themeName, QWidget *parent)
+    : QDialog(parent)
+{
+    setWindowTitle(
+        themeName.isEmpty() ? tr("Interface Theme Editor")
+                            : tr("Interface Theme Editor - <%1>").arg(themeName));
+
+    m_vars = themeName.isEmpty() ? Configuration::defaultInterfaceThemeVariables()
+                                 : Configuration::loadInterfaceThemeVariables(themeName);
+
+    listView = new ColorThemeListView(this);
+    listView->setSource(ColorSettingsModel::InterfacePalette);
+    listView->colorSettingsModel()->setInterfaceColors(m_vars);
+    colorPicker = new ColorPicker(this);
+
+    auto *top = new QHBoxLayout;
+    top->addWidget(listView, 1);
+    top->addWidget(colorPicker);
+
+    previewTimer = new QTimer(this);
+    previewTimer->setSingleShot(true);
+    previewTimer->setInterval(50);
+    connect(previewTimer, &QTimer::timeout, this, [this]() {
+        qApp->setStyleSheet(Configuration::buildInterfaceStyleSheet(m_vars));
+        Config()->setColor("navbarCode", m_vars.value("navbarCode"));
+        Config()->setColor("navbarString", m_vars.value("navbarString"));
+        Config()->setColor("navbarSymbol", m_vars.value("navbarSymbol"));
+        Config()->setColor("background", m_vars.value("background"));
+        emit Config()->colorsUpdated();
+    });
+
+    nameEdit = new QLineEdit(this);
+    nameEdit->setPlaceholderText(tr("Theme name"));
+    nameEdit->setText(themeName);
+    auto *nameRow = new QHBoxLayout;
+    nameRow->addWidget(new QLabel(tr("Save as:"), this));
+    nameRow->addWidget(nameEdit, 1);
+
+    auto *buttons = new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel, this);
+
+    auto *layout = new QVBoxLayout(this);
+    layout->addLayout(top);
+    layout->addLayout(nameRow);
+    layout->addWidget(buttons);
+
+    connect(listView, &ColorThemeListView::itemChanged, colorPicker, &ColorPicker::updateColor);
+    connect(
+        colorPicker,
+        &ColorPicker::colorChanged,
+        this,
+        &InterfaceThemeEditDialog::colorOptionChanged);
+    connect(buttons, &QDialogButtonBox::accepted, this, &QDialog::accept);
+    connect(buttons, &QDialogButtonBox::rejected, this, &QDialog::reject);
+
+    listView->setCurrentIndex(listView->model()->index(0, 0));
+}
+
+void InterfaceThemeEditDialog::colorOptionChanged(const QColor &newColor)
+{
+    const QModelIndex idx = listView->currentIndex();
+    if (!idx.isValid()) {
+        return;
+    }
+
+    ColorOption opt = idx.data(Qt::UserRole).value<ColorOption>();
+    opt.color = newColor;
+    opt.changed = true;
+    listView->model()->setData(idx, QVariant::fromValue(opt));
+
+    m_vars[opt.optionName] = newColor;
+    previewTimer->start();
+}
+
+void InterfaceThemeEditDialog::accept()
+{
+    const QString name = nameEdit->text().trimmed();
+    if (name.isEmpty()) {
+        QMessageBox::warning(this, tr("Interface Theme Editor"), tr("Please enter a theme name."));
+        return;
+    }
+    if (!Configuration::isValidThemeName(name)) {
+        QMessageBox::warning(this, tr("Interface Theme Editor"), tr("Invalid theme name."));
+        return;
+    }
+
+    Configuration::saveInterfaceThemeVariables(name, m_vars);
+    m_savedName = name;
+    QDialog::accept();
+}
+
+void InterfaceThemeEditDialog::reject()
+{
+    Config()->setInterfaceTheme(Config()->getInterfaceTheme());
+    QDialog::reject();
+}

--- a/src/dialogs/settings/InterfaceThemeEditDialog.h
+++ b/src/dialogs/settings/InterfaceThemeEditDialog.h
@@ -1,0 +1,40 @@
+#ifndef INTERFACETHEMEEDITDIALOG_H
+#define INTERFACETHEMEEDITDIALOG_H
+
+#include <QColor>
+#include <QDialog>
+#include <QHash>
+#include <QPalette>
+#include <QString>
+
+class ColorThemeListView;
+class ColorPicker;
+class QLineEdit;
+class QTimer;
+
+class InterfaceThemeEditDialog : public QDialog
+{
+    Q_OBJECT
+
+public:
+    explicit InterfaceThemeEditDialog(const QString &themeName = QString(), QWidget *parent = nullptr);
+
+    QString savedName() const { return m_savedName; }
+
+public slots:
+    void accept() override;
+    void reject() override;
+
+private slots:
+    void colorOptionChanged(const QColor &newColor);
+
+private:
+    ColorThemeListView *listView;
+    ColorPicker *colorPicker;
+    QLineEdit *nameEdit;
+    QTimer *previewTimer;
+    QHash<QString, QColor> m_vars;
+    QString m_savedName;
+};
+
+#endif // INTERFACETHEMEEDITDIALOG_H

--- a/src/themes/template/interface-template.qss
+++ b/src/themes/template/interface-template.qss
@@ -1,0 +1,131 @@
+* {
+    background-color: {{background}};
+    color: {{text}};
+    selection-background-color: {{accent}};
+    selection-color: {{accentText}};
+}
+QMainWindow, QDialog, QDockWidget {
+    background-color: {{background}};
+}
+
+QMenuBar {
+    background-color: {{panel}};
+    color: {{text}};
+}
+QMenuBar::item:selected {
+    background-color: {{surface}};
+}
+QMenu {
+    background-color: {{panel}};
+    color: {{text}};
+    border: 1px solid {{surface}};
+}
+QMenu::item:selected {
+    background-color: {{accent}};
+    color: {{accentText}};
+}
+
+QToolBar {
+    background-color: {{panel}};
+    border: none;
+    spacing: 2px;
+}
+QToolButton {
+    background-color: transparent;
+    border-radius: 4px;
+    padding: 2px;
+}
+QToolButton:hover {
+    background-color: {{surface}};
+}
+
+QTabBar::tab {
+    background-color: {{panel}};
+    color: {{mutedText}};
+    padding: 6px 10px;
+}
+QTabBar::tab:selected {
+    background-color: {{background}};
+    color: {{accent}};
+}
+QTabWidget::pane {
+    border: 1px solid {{surface}};
+}
+
+QHeaderView::section {
+    background-color: {{panel}};
+    color: {{text}};
+    border: none;
+    padding: 4px;
+}
+
+QAbstractItemView, QTreeView, QListView, QTableView {
+    background-color: {{background}};
+    color: {{text}};
+    alternate-background-color: {{panel}};
+    selection-background-color: {{surface}};
+    selection-color: {{text}};
+}
+
+QLineEdit, QPlainTextEdit, QTextEdit, QSpinBox, QComboBox {
+    background-color: {{panel}};
+    color: {{text}};
+    border: 1px solid {{surface}};
+    border-radius: 4px;
+    padding: 2px 4px;
+}
+
+QPushButton {
+    background-color: {{surface}};
+    color: {{text}};
+    border: 1px solid {{border}};
+    padding: 4px 10px;
+    border-radius: 4px;
+}
+QPushButton:hover {
+    background-color: {{border}};
+}
+QPushButton:disabled {
+    color: {{mutedText}};
+}
+
+QScrollBar:vertical {
+    background: {{panel}};
+    width: 12px;
+    margin: 0;
+}
+QScrollBar:horizontal {
+    background: {{panel}};
+    height: 12px;
+    margin: 0;
+}
+QScrollBar::handle {
+    background: {{border}};
+    border-radius: 4px;
+    min-height: 24px;
+    min-width: 24px;
+}
+QScrollBar::add-line, QScrollBar::sub-line {
+    background: none;
+    border: none;
+}
+
+QStatusBar {
+    background-color: {{panel}};
+    color: {{mutedText}};
+}
+QToolTip {
+    background-color: {{surface}};
+    color: {{text}};
+    border: 1px solid {{accent}};
+}
+QDockWidget::title {
+    background-color: {{panel}};
+    padding: 4px;
+}
+QSplitter::handle {
+    background-color: {{panel}};
+}
+*:disabled {
+    color: {{mutedText}};
+}

--- a/src/themes/template/template.qrc
+++ b/src/themes/template/template.qrc
@@ -1,0 +1,5 @@
+<RCC>
+    <qresource prefix="/template">
+        <file>interface-template.qss</file>
+    </qresource>
+</RCC>

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -27,6 +27,7 @@ struct OptionInfo
 };
 
 extern const QMap<QString, OptionInfo> optionInfoMap__;
+extern const QMap<QString, OptionInfo> paletteInfoMap__;
 
 ColorOptionDelegate::ColorOptionDelegate(QObject *parent)
     : QStyledItemDelegate(parent)
@@ -311,6 +312,12 @@ ColorSettingsModel *ColorThemeListView::colorSettingsModel() const
         static_cast<QSortFilterProxyModel *>(model())->sourceModel());
 }
 
+void ColorThemeListView::setSource(int source)
+{
+    colorSettingsModel()->setSource(static_cast<ColorSettingsModel::Source>(source));
+    setCurrentIndex(model()->index(0, 0));
+}
+
 void ColorThemeListView::blinkTimeout()
 {
     static enum { Normal, Invisible } state = Normal;
@@ -350,8 +357,11 @@ QVariant ColorSettingsModel::data(const QModelIndex &index, int role) const
         return QVariant();
     }
 
+    const QMap<QString, OptionInfo> &infoMap
+        = m_source == InterfacePalette ? paletteInfoMap__ : optionInfoMap__;
+
     if (role == Qt::DisplayRole) {
-        return QVariant::fromValue(optionInfoMap__[theme.at(index.row()).optionName].displayingtext);
+        return QVariant::fromValue(infoMap[theme.at(index.row()).optionName].displayingtext);
     }
 
     if (role == Qt::UserRole) {
@@ -359,14 +369,13 @@ QVariant ColorSettingsModel::data(const QModelIndex &index, int role) const
     }
 
     if (role == Qt::ToolTipRole) {
-        return QVariant::fromValue(optionInfoMap__[theme.at(index.row()).optionName].info);
+        return QVariant::fromValue(infoMap[theme.at(index.row()).optionName].info);
     }
 
     if (role == allFieldsRole) {
         const QString name = theme.at(index.row()).optionName;
         return QVariant::fromValue(
-            optionInfoMap__[name].displayingtext + " "
-            + optionInfoMap__[theme.at(index.row()).optionName].info + " " + name);
+            infoMap[name].displayingtext + " " + infoMap[name].info + " " + name);
     }
 
     return QVariant();
@@ -384,31 +393,54 @@ bool ColorSettingsModel::setData(const QModelIndex &index, const QVariant &value
     return true;
 }
 
+void ColorSettingsModel::setSource(Source source)
+{
+    m_source = source;
+    updateTheme();
+}
+
+void ColorSettingsModel::setInterfaceColors(const QHash<QString, QColor> &colors)
+{
+    m_interfaceColors = colors;
+    if (m_source == InterfacePalette) {
+        updateTheme();
+    }
+}
+
 void ColorSettingsModel::updateTheme()
 {
+    beginResetModel();
     theme.clear();
-    QJsonObject obj = ThemeWorker().getTheme(Config()->getColorTheme()).object();
+    const QMap<QString, OptionInfo> &infoMap
+        = m_source == InterfacePalette ? paletteInfoMap__ : optionInfoMap__;
 
-    for (auto it = obj.constBegin(); it != obj.constEnd(); it++) {
-        QJsonArray rgb = it.value().toArray();
-        if (rgb.size() != 4) {
-            continue;
+    if (m_source == InterfacePalette) {
+        const QHash<QString, QColor> colors = m_interfaceColors.isEmpty()
+            ? Configuration::defaultInterfaceThemeVariables()
+            : m_interfaceColors;
+        for (const QString &key : Configuration::interfaceThemeVariableKeys()) {
+            theme.push_back({key, colors.value(key), false});
         }
-        theme.push_back(
-            {it.key(),
-             QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt(), rgb[3].toInt()),
-             false});
+    } else {
+        QJsonObject obj = ThemeWorker().getTheme(Config()->getColorTheme()).object();
+        for (auto it = obj.constBegin(); it != obj.constEnd(); it++) {
+            QJsonArray rgb = it.value().toArray();
+            if (rgb.size() != 4) {
+                continue;
+            }
+            theme.push_back(
+                {it.key(),
+                 QColor(rgb[0].toInt(), rgb[1].toInt(), rgb[2].toInt(), rgb[3].toInt()),
+                 false});
+        }
     }
 
-    std::sort(theme.begin(), theme.end(), [](const ColorOption &f, const ColorOption &s) {
-        QString s1 = optionInfoMap__[f.optionName].displayingtext;
-        QString s2 = optionInfoMap__[s.optionName].displayingtext;
-        int r = s1.compare(s2, Qt::CaseSensitivity::CaseInsensitive);
-        return r < 0;
+    std::sort(theme.begin(), theme.end(), [&infoMap](const ColorOption &f, const ColorOption &s) {
+        return infoMap[f.optionName].displayingtext.compare(
+                   infoMap[s.optionName].displayingtext, Qt::CaseInsensitive)
+            < 0;
     });
-    if (!theme.isEmpty()) {
-        dataChanged(index(0), index(theme.size() - 1));
-    }
+    endResetModel();
 }
 
 QJsonDocument ColorSettingsModel::getTheme() const
@@ -534,3 +566,19 @@ const QMap<QString, OptionInfo> optionInfoMap__ = {
     {"ucall", {"", QObject::tr("ucall")}},
     {"ujmp", {"", QObject::tr("ujmp")}},
     {"gui.breakpoint_background", {"", QObject::tr("Breakpoint background")}}};
+
+const QMap<QString, OptionInfo> paletteInfoMap__ = {
+    {"background", {QObject::tr("Main window and editor background"), QObject::tr("Background")}},
+    {"panel",
+     {QObject::tr("Panels, menus, toolbars, inputs and scrollbar track"), QObject::tr("Panel")}},
+    {"surface", {QObject::tr("Buttons, list selection and tooltips"), QObject::tr("Surface")}},
+    {"border",
+     {QObject::tr("Borders, outlines, button hover and scrollbar handle"), QObject::tr("Border")}},
+    {"text", {QObject::tr("Primary text"), QObject::tr("Text")}},
+    {"mutedText", {QObject::tr("Dim and disabled text"), QObject::tr("Muted text")}},
+    {"accent", {QObject::tr("Selection and accent color"), QObject::tr("Accent")}},
+    {"accentText", {QObject::tr("Text drawn over the accent color"), QObject::tr("Accent text")}},
+    {"navbarCode", {QObject::tr("Navigation bar: code regions"), QObject::tr("Navbar code")}},
+    {"navbarString", {QObject::tr("Navigation bar: string regions"), QObject::tr("Navbar strings")}},
+    {"navbarSymbol",
+     {QObject::tr("Navigation bar: symbol regions"), QObject::tr("Navbar symbols")}}};

--- a/src/widgets/ColorThemeListView.h
+++ b/src/widgets/ColorThemeListView.h
@@ -26,6 +26,7 @@ public:
     virtual ~ColorThemeListView() override {}
 
     ColorSettingsModel *colorSettingsModel() const;
+    void setSource(int source);
 
 protected slots:
     void currentChanged(const QModelIndex &current, const QModelIndex &previous) override;
@@ -61,8 +62,13 @@ class ColorSettingsModel : public QAbstractListModel
 {
     Q_OBJECT
 public:
+    enum Source { ContentColors, InterfacePalette };
+
     ColorSettingsModel(QObject *parent = nullptr);
     virtual ~ColorSettingsModel() override {}
+
+    void setSource(Source source);
+    void setInterfaceColors(const QHash<QString, QColor> &colors);
 
     QVariant data(const QModelIndex &index, int role = Qt::DisplayRole) const override;
 
@@ -80,6 +86,8 @@ public:
 
 private:
     QList<ColorOption> theme;
+    Source m_source = ContentColors;
+    QHash<QString, QColor> m_interfaceColors;
 };
 
 class ColorOptionDelegate : public QStyledItemDelegate

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -582,8 +582,8 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block,
         }
     }
 
-    p.setPen(Qt::black);
-    p.setBrush(Qt::gray);
+    p.setPen(graphNodeColor);
+    p.setBrush(disassemblyBackgroundColor);
     p.setFont(Config()->getFont());
     p.drawRect(blockRect);
 

--- a/src/widgets/HexWidget.cpp
+++ b/src/widgets/HexWidget.cpp
@@ -97,7 +97,7 @@ void HexWidget::updateFlagBackgroundRanges()
         }
 
         RFlagItemMeta *fim = r_flag_get_meta(rf, fi->id);
-        QColor bg = (fim && fim->color) ? QColor(QString::fromUtf8(fim->color)) : QColor(Qt::gray);
+        QColor bg = (fim && fim->color) ? QColor(QString::fromUtf8(fim->color)) : borderColor;
         bg.setAlphaF(0.3);
         flagBackgroundRanges.append({start, end, bg});
         if (addr == lastAddr) {

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -62,8 +62,8 @@ void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block, bool int
     Q_UNUSED(interactive)
     QRectF blockRect(block.x, block.y, block.width, block.height);
 
-    p.setPen(Qt::black);
-    p.setBrush(Qt::gray);
+    p.setPen(graphNodeColor);
+    p.setBrush(disassemblyBackgroundColor);
     p.drawRect(blockRect);
     p.setBrush(QColor(0, 0, 0, 100));
     p.drawRect(blockRect.translated(2, 2));

--- a/src/widgets/SimpleTextGraphView.cpp
+++ b/src/widgets/SimpleTextGraphView.cpp
@@ -90,8 +90,8 @@ void SimpleTextGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block, b
 
     const qreal padding = charWidth;
 
-    p.setPen(Qt::black);
-    p.setBrush(Qt::gray);
+    p.setPen(graphNodeColor);
+    p.setBrush(disassemblyBackgroundColor);
     p.setFont(Config()->getFont());
     p.drawRect(blockRect);
 

--- a/src/widgets/VisualNavbar.cpp
+++ b/src/widgets/VisualNavbar.cpp
@@ -273,14 +273,14 @@ QColor VisualNavbar::colorForDataType(DataType dataType) const
 
     switch (dataType) {
     case DataType::Code:
-        return Config()->getColor("gui.navbar.code");
+        return Config()->getColor("navbarCode");
     case DataType::String:
-        return Config()->getColor("gui.navbar.str");
+        return Config()->getColor("navbarString");
     case DataType::Symbol:
-        return Config()->getColor("gui.navbar.sym");
+        return Config()->getColor("navbarSymbol");
     case DataType::Empty:
     case DataType::Count:
-        return Config()->getColor("gui.navbar.empty");
+        return Config()->getColor("background");
     }
 
     return QColor();


### PR DESCRIPTION
Remove hardcoded colors

Wire interface theming into an UI

**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<!-- Explain in detail the purpose of this contribution, with enough information to help us understand better the patch -->

Adds customization to the user interface. 

<img width="1920" height="1080" alt="Screenshot From 2026-06-05 21-33-01" src="https://github.com/user-attachments/assets/2b368a49-2d1d-4a61-a755-8ca1210c9cd7" />

<img width="950" height="662" alt="Screenshot From 2026-06-05 21-33-29" src="https://github.com/user-attachments/assets/7b18e35a-3449-41da-9e11-a5e578c090cf" />

