### PR TITLE
Add syntax-colored minimap to graph blocks

### DIFF
--- a/src/common/Configuration.cpp
+++ b/src/common/Configuration.cpp
@@ -563,7 +563,7 @@ void Configuration::loadClassicStylesheet()
 QString Configuration::userThemesDir()
 {
     const QString dir = QStandardPaths::writableLocation(QStandardPaths::AppDataLocation)
-        + QDir::separator() + QStringLiteral("themes");
+                        + QDir::separator() + QStringLiteral("themes");
     QDir().mkpath(dir);
     return dir;
 }
@@ -580,18 +580,18 @@ bool Configuration::isValidThemeName(const QString &name)
 
 const QStringList &Configuration::interfaceThemeVariableKeys()
 {
-    static const QStringList keys = {
-        "background",
-        "panel",
-        "surface",
-        "border",
-        "text",
-        "mutedText",
-        "accent",
-        "accentText",
-        "navbarCode",
-        "navbarString",
-        "navbarSymbol"};
+    static const QStringList keys
+        = {"background",
+           "panel",
+           "surface",
+           "border",
+           "text",
+           "mutedText",
+           "accent",
+           "accentText",
+           "navbarCode",
+           "navbarString",
+           "navbarSymbol"};
     return keys;
 }
 
@@ -621,8 +621,8 @@ QHash<QString, QColor> Configuration::defaultInterfaceThemeVariables()
 QHash<QString, QColor> Configuration::loadInterfaceThemeVariables(const QString &name)
 {
     QHash<QString, QColor> vars = defaultInterfaceThemeVariables();
-    QSettings theme(
-        QDir(userThemesDir()).filePath(name + QStringLiteral(".theme")), QSettings::IniFormat);
+    QSettings
+        theme(QDir(userThemesDir()).filePath(name + QStringLiteral(".theme")), QSettings::IniFormat);
     for (const QString &key : interfaceThemeVariableKeys()) {
         const QColor color(theme.value(key).toString());
         if (color.isValid()) {
@@ -635,8 +635,8 @@ QHash<QString, QColor> Configuration::loadInterfaceThemeVariables(const QString 
 void Configuration::saveInterfaceThemeVariables(
     const QString &name, const QHash<QString, QColor> &vars)
 {
-    QSettings theme(
-        QDir(userThemesDir()).filePath(name + QStringLiteral(".theme")), QSettings::IniFormat);
+    QSettings
+        theme(QDir(userThemesDir()).filePath(name + QStringLiteral(".theme")), QSettings::IniFormat);
     for (const QString &key : interfaceThemeVariableKeys()) {
         theme.setValue(key, vars.value(key).name());
     }
@@ -1028,14 +1028,15 @@ void Configuration::applySavedAsmOptions()
 const QList<IaitoInterfaceTheme> &Configuration::iaitoInterfaceThemesList()
 {
     static QList<IaitoInterfaceTheme> list;
-    list = {{"Native", Configuration::nativeWindowIsDark() ? DarkFlag : LightFlag},
-            {"Dark", DarkFlag},
-            {"Midnight", DarkFlag},
-            {"Light", LightFlag},
-            {"Classic", LightFlag}};
-    const auto userThemes = QDir(userThemesDir())
-                                .entryInfoList(
-                                    QStringList{QStringLiteral("*.theme")}, QDir::Files, QDir::Name);
+    list
+        = {{"Native", Configuration::nativeWindowIsDark() ? DarkFlag : LightFlag},
+           {"Dark", DarkFlag},
+           {"Midnight", DarkFlag},
+           {"Light", LightFlag},
+           {"Classic", LightFlag}};
+    const auto userThemes
+        = QDir(userThemesDir())
+              .entryInfoList(QStringList{QStringLiteral("*.theme")}, QDir::Files, QDir::Name);
     for (const QFileInfo &fi : userThemes) {
         list.append({fi.completeBaseName(), DarkFlag});
     }

--- a/src/dialogs/settings/AppearanceOptionsWidget.cpp
+++ b/src/dialogs/settings/AppearanceOptionsWidget.cpp
@@ -5,8 +5,8 @@
 #include <QInputDialog>
 #include <QLabel>
 #include <QPainter>
-#include <QSignalBlocker>
 #include <QSettings>
+#include <QSignalBlocker>
 #include <QStandardPaths>
 #include <QTranslator>
 #include <QtSvg/QSvgRenderer>
@@ -437,8 +437,8 @@ void AppearanceOptionsWidget::on_ifaceExportButton_clicked()
         return;
     }
     const QHash<QString, QColor> vars = Configuration::isCustomInterfaceTheme(current)
-        ? Configuration::loadInterfaceThemeVariables(current)
-        : Configuration::defaultInterfaceThemeVariables();
+                                            ? Configuration::loadInterfaceThemeVariables(current)
+                                            : Configuration::defaultInterfaceThemeVariables();
     QSettings out(file, QSettings::IniFormat);
     for (const QString &key : Configuration::interfaceThemeVariableKeys()) {
         out.setValue(key, vars.value(key).name());
@@ -462,7 +462,8 @@ void AppearanceOptionsWidget::on_ifaceImportButton_clicked()
         return;
     }
     const QString name = QFileInfo(fileName).completeBaseName();
-    const QString dst = QDir(Configuration::userThemesDir()).filePath(name + QStringLiteral(".theme"));
+    const QString dst
+        = QDir(Configuration::userThemesDir()).filePath(name + QStringLiteral(".theme"));
     if (QFileInfo::exists(dst)) {
         QFile::remove(dst);
     }

--- a/src/dialogs/settings/InterfaceThemeEditDialog.cpp
+++ b/src/dialogs/settings/InterfaceThemeEditDialog.cpp
@@ -41,7 +41,7 @@ InterfaceThemeEditDialog::InterfaceThemeEditDialog(const QString &themeName, QWi
         Config()->setColor("navbarString", m_vars.value("navbarString"));
         Config()->setColor("navbarSymbol", m_vars.value("navbarSymbol"));
         Config()->setColor("background", m_vars.value("background"));
-        emit Config()->colorsUpdated();
+        emit Config() -> colorsUpdated();
     });
 
     nameEdit = new QLineEdit(this);

--- a/src/dialogs/settings/InterfaceThemeEditDialog.h
+++ b/src/dialogs/settings/InterfaceThemeEditDialog.h
@@ -17,7 +17,8 @@ class InterfaceThemeEditDialog : public QDialog
     Q_OBJECT
 
 public:
-    explicit InterfaceThemeEditDialog(const QString &themeName = QString(), QWidget *parent = nullptr);
+    explicit InterfaceThemeEditDialog(
+        const QString &themeName = QString(), QWidget *parent = nullptr);
 
     QString savedName() const { return m_savedName; }
 

--- a/src/widgets/ColorThemeListView.cpp
+++ b/src/widgets/ColorThemeListView.cpp
@@ -357,8 +357,8 @@ QVariant ColorSettingsModel::data(const QModelIndex &index, int role) const
         return QVariant();
     }
 
-    const QMap<QString, OptionInfo> &infoMap
-        = m_source == InterfacePalette ? paletteInfoMap__ : optionInfoMap__;
+    const QMap<QString, OptionInfo> &infoMap = m_source == InterfacePalette ? paletteInfoMap__
+                                                                            : optionInfoMap__;
 
     if (role == Qt::DisplayRole) {
         return QVariant::fromValue(infoMap[theme.at(index.row()).optionName].displayingtext);
@@ -411,13 +411,13 @@ void ColorSettingsModel::updateTheme()
 {
     beginResetModel();
     theme.clear();
-    const QMap<QString, OptionInfo> &infoMap
-        = m_source == InterfacePalette ? paletteInfoMap__ : optionInfoMap__;
+    const QMap<QString, OptionInfo> &infoMap = m_source == InterfacePalette ? paletteInfoMap__
+                                                                            : optionInfoMap__;
 
     if (m_source == InterfacePalette) {
         const QHash<QString, QColor> colors = m_interfaceColors.isEmpty()
-            ? Configuration::defaultInterfaceThemeVariables()
-            : m_interfaceColors;
+                                                  ? Configuration::defaultInterfaceThemeVariables()
+                                                  : m_interfaceColors;
         for (const QString &key : Configuration::interfaceThemeVariableKeys()) {
             theme.push_back({key, colors.value(key), false});
         }
@@ -436,9 +436,9 @@ void ColorSettingsModel::updateTheme()
     }
 
     std::sort(theme.begin(), theme.end(), [&infoMap](const ColorOption &f, const ColorOption &s) {
-        return infoMap[f.optionName].displayingtext.compare(
-                   infoMap[s.optionName].displayingtext, Qt::CaseInsensitive)
-            < 0;
+        return infoMap[f.optionName]
+                   .displayingtext.compare(infoMap[s.optionName].displayingtext, Qt::CaseInsensitive)
+               < 0;
     });
     endResetModel();
 }
@@ -567,18 +567,20 @@ const QMap<QString, OptionInfo> optionInfoMap__ = {
     {"ujmp", {"", QObject::tr("ujmp")}},
     {"gui.breakpoint_background", {"", QObject::tr("Breakpoint background")}}};
 
-const QMap<QString, OptionInfo> paletteInfoMap__ = {
-    {"background", {QObject::tr("Main window and editor background"), QObject::tr("Background")}},
-    {"panel",
-     {QObject::tr("Panels, menus, toolbars, inputs and scrollbar track"), QObject::tr("Panel")}},
-    {"surface", {QObject::tr("Buttons, list selection and tooltips"), QObject::tr("Surface")}},
-    {"border",
-     {QObject::tr("Borders, outlines, button hover and scrollbar handle"), QObject::tr("Border")}},
-    {"text", {QObject::tr("Primary text"), QObject::tr("Text")}},
-    {"mutedText", {QObject::tr("Dim and disabled text"), QObject::tr("Muted text")}},
-    {"accent", {QObject::tr("Selection and accent color"), QObject::tr("Accent")}},
-    {"accentText", {QObject::tr("Text drawn over the accent color"), QObject::tr("Accent text")}},
-    {"navbarCode", {QObject::tr("Navigation bar: code regions"), QObject::tr("Navbar code")}},
-    {"navbarString", {QObject::tr("Navigation bar: string regions"), QObject::tr("Navbar strings")}},
-    {"navbarSymbol",
-     {QObject::tr("Navigation bar: symbol regions"), QObject::tr("Navbar symbols")}}};
+const QMap<QString, OptionInfo> paletteInfoMap__
+    = {{"background", {QObject::tr("Main window and editor background"), QObject::tr("Background")}},
+       {"panel",
+        {QObject::tr("Panels, menus, toolbars, inputs and scrollbar track"), QObject::tr("Panel")}},
+       {"surface", {QObject::tr("Buttons, list selection and tooltips"), QObject::tr("Surface")}},
+       {"border",
+        {QObject::tr("Borders, outlines, button hover and scrollbar handle"),
+         QObject::tr("Border")}},
+       {"text", {QObject::tr("Primary text"), QObject::tr("Text")}},
+       {"mutedText", {QObject::tr("Dim and disabled text"), QObject::tr("Muted text")}},
+       {"accent", {QObject::tr("Selection and accent color"), QObject::tr("Accent")}},
+       {"accentText", {QObject::tr("Text drawn over the accent color"), QObject::tr("Accent text")}},
+       {"navbarCode", {QObject::tr("Navigation bar: code regions"), QObject::tr("Navbar code")}},
+       {"navbarString",
+        {QObject::tr("Navigation bar: string regions"), QObject::tr("Navbar strings")}},
+       {"navbarSymbol",
+        {QObject::tr("Navigation bar: symbol regions"), QObject::tr("Navbar symbols")}}};

--- a/src/widgets/DisassemblerGraphView.cpp
+++ b/src/widgets/DisassemblerGraphView.cpp
@@ -443,6 +443,60 @@ DisassemblerGraphView::EdgeConfigurationMapping DisassemblerGraphView::getEdgeCo
     return result;
 }
 
+DisassemblerGraphView::MinimapBars DisassemblerGraphView::getMinimapBars()
+{
+    MinimapBars result;
+    const qreal padding = 2 * charWidth;
+    for (auto &blockIt : blocks) {
+        GraphBlock &block = blockIt.second;
+        auto dbIt = disassembly_blocks.find(block.entry);
+        if (dbIt == disassembly_blocks.end()) {
+            continue;
+        }
+        DisassemblyBlock &db = dbIt->second;
+        std::vector<MinimapBar> bars;
+        const qreal maxX = block.x + block.width - padding;
+        const qreal barHeight = qMax<qreal>(1.0, charHeight * 0.6);
+        int y = block.y + getTextOffset(0).y();
+        auto addLine = [&](const RichTextPainter::List &line) {
+            qreal cx = block.x + padding;
+            const qreal barY = y + (charHeight - barHeight) / 2.0;
+            for (const auto &segment : line) {
+                const qreal segWidth = segment.text.length() * charWidth;
+                if (!segment.text.trimmed().isEmpty()) {
+                    const QColor color = (segment.flags == RichTextPainter::FlagColor
+                                          || segment.flags == RichTextPainter::FlagAll)
+                                             ? segment.textColor
+                                             : graphNodeColor;
+                    bars.push_back({QRectF(cx, barY, qMin(segWidth, maxX - cx), barHeight), color});
+                }
+                cx += segWidth;
+                if (cx >= maxX) {
+                    break;
+                }
+            }
+        };
+        const bool hasTitleBar = Config()->getGraphBlockEntryOffset()
+                                 && !db.header_text.lines.empty();
+        if (hasTitleBar) {
+            y += int(db.header_text.lines.size()) * charHeight;
+        } else {
+            for (auto &line : db.header_text.lines) {
+                addLine(line);
+                y += charHeight;
+            }
+        }
+        for (const Instr &instr : db.instrs) {
+            for (auto &line : instr.text.lines) {
+                addLine(line);
+                y += charHeight;
+            }
+        }
+        result[block.entry] = std::move(bars);
+    }
+    return result;
+}
+
 void DisassemblerGraphView::appendJsonDisassemblyBlockContent(
     DisassemblyBlock &db, const QJsonArray &opArray, RVA blockEntry, RVA blockSize)
 {
@@ -692,11 +746,51 @@ void DisassemblerGraphView::drawBlock(QPainter &p, GraphView::GraphBlock &block,
 
     const int firstInstructionY = block.y + getInstructionOffset(db, 0).y();
 
-    // Stop rendering text when it's too small
     auto transform = p.combinedTransform();
     QRect screenChar = transform.mapRect(QRect(0, 0, charWidth, charHeight));
+    const int screenCharWidth = screenChar.width() * qhelpers::devicePixelRatio(p.device());
 
-    if (screenChar.width() * qhelpers::devicePixelRatio(p.device()) < 4) {
+    if (screenCharWidth < 4) {
+        if (screenCharWidth < 1) {
+            return;
+        }
+        const qreal maxX = block.x + block.width - padding;
+        const qreal barHeight = qMax<qreal>(1.0, charHeight * 0.6);
+        auto paintMinimapLine = [&](const RichTextPainter::List &line, int lineY) {
+            qreal cx = block.x + padding;
+            const qreal barY = lineY + (charHeight - barHeight) / 2.0;
+            for (const auto &segment : line) {
+                const qreal segWidth = segment.text.length() * charWidth;
+                if (!segment.text.trimmed().isEmpty()) {
+                    const QColor color = (segment.flags == RichTextPainter::FlagColor
+                                          || segment.flags == RichTextPainter::FlagAll)
+                                             ? segment.textColor
+                                             : graphNodeColor;
+                    p.fillRect(QRectF(cx, barY, qMin(segWidth, maxX - cx), barHeight), color);
+                }
+                cx += segWidth;
+                if (cx >= maxX) {
+                    break;
+                }
+            }
+        };
+
+        p.setPen(Qt::NoPen);
+        int minimapY = block.y + getTextOffset(0).y();
+        if (hasTitleBar) {
+            minimapY += int(db.header_text.lines.size()) * charHeight;
+        } else {
+            for (auto &line : db.header_text.lines) {
+                paintMinimapLine(line, minimapY);
+                minimapY += charHeight;
+            }
+        }
+        for (const Instr &instr : db.instrs) {
+            for (auto &line : instr.text.lines) {
+                paintMinimapLine(line, minimapY);
+                minimapY += charHeight;
+            }
+        }
         return;
     }
 

--- a/src/widgets/DisassemblerGraphView.h
+++ b/src/widgets/DisassemblerGraphView.h
@@ -128,6 +128,14 @@ public:
     using EdgeConfigurationMapping = std::map<std::pair<ut64, ut64>, EdgeConfiguration>;
     EdgeConfigurationMapping getEdgeConfigurations();
 
+    struct MinimapBar
+    {
+        QRectF rect;
+        QColor color;
+    };
+    using MinimapBars = std::unordered_map<ut64, std::vector<MinimapBar>>;
+    MinimapBars getMinimapBars();
+
     /**
      * @brief keep the current addr of the fcn of Graph
      * Everytime overview updates its contents, it compares this value with the

--- a/src/widgets/OverviewView.cpp
+++ b/src/widgets/OverviewView.cpp
@@ -23,12 +23,14 @@ void OverviewView::setData(
     int baseWidth,
     int baseHeight,
     std::unordered_map<ut64, GraphBlock> baseBlocks,
-    DisassemblerGraphView::EdgeConfigurationMapping baseEdgeConfigurations)
+    DisassemblerGraphView::EdgeConfigurationMapping baseEdgeConfigurations,
+    DisassemblerGraphView::MinimapBars baseMinimapBars)
 {
     width = baseWidth;
     height = baseHeight;
     blocks = baseBlocks;
     edgeConfigurations = baseEdgeConfigurations;
+    minimapBars = baseMinimapBars;
     scaleAndCenter();
     setCacheDirty();
     viewport()->update();
@@ -79,6 +81,14 @@ void OverviewView::drawBlock(QPainter &p, GraphView::GraphBlock &block, bool int
     }
     p.setPen(QPen(graphNodeColor, 1));
     p.drawRect(blockRect);
+
+    auto barsIt = minimapBars.find(block.entry);
+    if (barsIt != minimapBars.end()) {
+        p.setPen(Qt::NoPen);
+        for (const auto &bar : barsIt->second) {
+            p.fillRect(bar.rect, bar.color);
+        }
+    }
 }
 
 void OverviewView::paintEvent(QPaintEvent *event)

--- a/src/widgets/OverviewView.h
+++ b/src/widgets/OverviewView.h
@@ -35,12 +35,14 @@ public:
      * @param baseHeigh height of Graph when it computed the blocks
      * @param baseBlocks computed blocks passed by Graph
      * @param baseEdgeConfigurations computed by DisassamblerGraphview
+     * @param baseMinimapBars per-block minimap bars computed by Graph
      */
     void setData(
         int baseWidth,
         int baseHeight,
         std::unordered_map<ut64, GraphBlock> baseBlocks,
-        DisassemblerGraphView::EdgeConfigurationMapping baseEdgeConfigurations);
+        DisassemblerGraphView::EdgeConfigurationMapping baseEdgeConfigurations,
+        DisassemblerGraphView::MinimapBars baseMinimapBars);
 
     void centreRect();
 
@@ -154,6 +156,11 @@ private:
      * @brief edgeConfigurations edge styles computed by DisassemblerGraphView
      */
     DisassemblerGraphView::EdgeConfigurationMapping edgeConfigurations;
+
+    /**
+     * @brief per-block minimap bars computed by DisassemblerGraphView
+     */
+    DisassemblerGraphView::MinimapBars minimapBars;
 
 public:
     QRectF getRangeRect() { return rangeRect; }

--- a/src/widgets/OverviewWidget.cpp
+++ b/src/widgets/OverviewWidget.cpp
@@ -193,10 +193,11 @@ void OverviewWidget::updateGraphData()
             mainGraphView.getWidth(),
             mainGraphView.getHeight(),
             mainGraphView.getBlocks(),
-            mainGraphView.getEdgeConfigurations());
+            mainGraphView.getEdgeConfigurations(),
+            mainGraphView.getMinimapBars());
     } else {
         graphView->currentFcnAddr = RVA_INVALID;
-        graphView->setData(0, 0, {}, {});
+        graphView->setData(0, 0, {}, {}, {});
         graphView->setRangeRect(QRectF(0, 0, 0, 0));
     }
 }


### PR DESCRIPTION
**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<img width="379" height="294" alt="Screenshot From 2026-06-06 16-43-14" src="https://github.com/user-attachments/assets/3e4a19e7-7d56-4536-9628-a8e19a2c5110" />
<img width="1146" height="860" alt="Screenshot From 2026-06-06 16-43-30" src="https://github.com/user-attachments/assets/71e2fcf5-0178-4e2e-8bbd-c2f4004831ee" />
