### PR TITLE
Override default CT_MenuItem sizing

### DIFF
--- a/src/common/theme/IaitoStyle.cpp
+++ b/src/common/theme/IaitoStyle.cpp
@@ -1347,6 +1347,26 @@ QSize IaitoStyle::sizeFromContents(
         s.setWidth(s.width() + 4 * m_theme.metrics.menuItemPadding);
         s.setHeight(qMax(s.height(), contentsSize.height() + 2 * m_theme.metrics.menuItemPadding));
         break;
+    case CT_MenuItem:
+        if (const auto *mi = qstyleoption_cast<const QStyleOptionMenuItem *>(option)) {
+            if (mi->menuItemType != QStyleOptionMenuItem::Separator) {
+                const QFontMetrics fm(mi->font);
+                QString text = mi->text;
+                QString shortcut;
+                const int tab = text.indexOf(QLatin1Char('\t'));
+                if (tab >= 0) {
+                    shortcut = text.mid(tab + 1);
+                    text = text.left(tab);
+                }
+                int w = m_theme.metrics.menuItemPadding + qMax(mi->maxIconWidth, 20)
+                        + fm.horizontalAdvance(text) + 22;
+                if (!shortcut.isEmpty()) {
+                    w += fm.horizontalAdvance(shortcut) + 20;
+                }
+                s.setWidth(qMax(s.width(), w));
+            }
+        }
+        break;
     default:
         break;
     }


### PR DESCRIPTION
Fixes truncated menu items

**Checklist**

- [ ] Closing issues: #issue
- [X] Mark this if you consider it ready to merge
- [ ] I've added tests (optional)
- [ ] I wrote some documentation

**Description**

<img width="270" height="204" alt="Screenshot From 2026-06-09 11-51-38" src="https://github.com/user-attachments/assets/9107cc42-fc24-4817-b1ae-900c895cfe30" />

<img width="270" height="204" alt="Screenshot From 2026-06-09 11-56-45" src="https://github.com/user-attachments/assets/1f0b1301-b9a6-4da4-8861-f3925b7ce502" />

