### PR TITLE
Fix #311 - Scroll the disassembly by lines instead of instructions

### DIFF
--- a/src/widgets/DisassemblyWidget.cpp
+++ b/src/widgets/DisassemblyWidget.cpp
@@ -29,6 +29,7 @@
 #include <QTextBlockUserData>
 #include <QToolTip>
 #include <QVBoxLayout>
+#include <QWheelEvent>
 
 class DisassemblyTextBlockUserData : public QTextBlockUserData
 {
@@ -120,13 +121,13 @@ static bool xrefIsCall(const XrefDescription &xref)
 DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     : MemoryDockWidget(MemoryWidgetType::Disassembly, main)
     , mCtxMenu(new DisassemblyContextMenu(this, main))
-    , mDisasScrollArea(new DisassemblyScrollArea(this))
     , mDisasTextEdit(new DisassemblyTextEdit(this))
 {
     setObjectName(main ? main->getUniqueObjectName(getWidgetType()) : getWidgetType());
     updateWindowTitle();
 
     topOffset = bottomOffset = RVA_INVALID;
+    wheelRemainder = 0;
     cursorLineOffset = 0;
     cursorCharOffset = 0;
     seekFromCursor = false;
@@ -146,27 +147,15 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
     splitter->addWidget(leftPanel);
 
     // Setup the disassembly content
-    auto *layout = new QHBoxLayout;
-    layout->setSizeConstraint(QLayout::SetNoConstraint);
-    layout->addWidget(mDisasTextEdit);
-    layout->setContentsMargins(0, 0, 0, 0);
-    mDisasScrollArea->viewport()->setLayout(layout);
-    mDisasScrollArea->setMinimumHeight(0);
-    mDisasScrollArea->viewport()->setMinimumHeight(0);
-    mDisasScrollArea->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Ignored);
     mDisasTextEdit->setMinimumHeight(0);
     mDisasTextEdit->viewport()->setMinimumHeight(0);
     mDisasTextEdit->setSizePolicy(QSizePolicy::Preferred, QSizePolicy::Ignored);
-    splitter->addWidget(mDisasScrollArea);
+    splitter->addWidget(mDisasTextEdit);
     // Use stylesheet instead of QWidget::setFrameShape(QFrame::NoShape) to
     // avoid issues with dark and light interface themes
     mDisasTextEdit->setStyleSheet("QPlainTextEdit { border: 0px transparent black; }");
     mDisasTextEdit->setFocusProxy(this);
     mDisasTextEdit->setFocusPolicy(Qt::ClickFocus);
-    mDisasScrollArea->setStyleSheet("QAbstractScrollArea { border: 0px transparent black; }");
-    mDisasScrollArea->setFocusProxy(this);
-    mDisasScrollArea->setVerticalScrollBarPolicy(Qt::ScrollBarPolicy::ScrollBarAlwaysOff);
-    mDisasScrollArea->setFocusPolicy(Qt::ClickFocus);
 
     setFocusPolicy(Qt::ClickFocus);
 
@@ -219,17 +208,6 @@ DisassemblyWidget::DisassemblyWidget(MainWindow *main)
         &QWidget::customContextMenuRequested,
         this,
         &DisassemblyWidget::showDisasContextMenu);
-
-    connect(
-        mDisasScrollArea,
-        &DisassemblyScrollArea::scrollLines,
-        this,
-        &DisassemblyWidget::scrollInstructions);
-    connect(
-        mDisasScrollArea,
-        &DisassemblyScrollArea::disassemblyResized,
-        this,
-        &DisassemblyWidget::updateMaxLines);
 
     connectCursorPositionChanged(false);
     connect(mDisasTextEdit->verticalScrollBar(), &QScrollBar::valueChanged, this, [this](int value) {
@@ -502,19 +480,81 @@ void DisassemblyWidget::refreshDisasm(RVA offset)
     leftPanel->update();
 }
 
-void DisassemblyWidget::scrollInstructions(int count)
+/**
+ * @brief Scroll the listing by `count` rendered lines (negative scrolls back).
+ *
+ * The view is drawn with `pdJ`, which yields one entry per *line*, while a
+ * single address may render several of them (comments, xrefs, labels). Moving
+ * the top address by instructions would therefore scroll a different amount of
+ * lines up than down, so pick the address of the line `count` rows away and let
+ * both directions agree.
+ */
+void DisassemblyWidget::scrollLines(int count)
 {
     if (count == 0 || topOffset == RVA_INVALID) {
         return;
     }
-    RVA offset = (count > 0) ? Core()->nextOpAddr(topOffset, count)
-                             : Core()->prevOpAddr(topOffset, -count);
+
+    QList<DisassemblyLine> listing = lines;
+    int index = count;
+    if (count < 0) {
+        // Every instruction renders at least one line, so stepping back `count`
+        // instructions is guaranteed to cover at least `count` lines.
+        const RVA start = Core()->prevOpAddr(topOffset, -count);
+        if (start >= topOffset) {
+            return;
+        }
+        listing = Core()->disassembleLines(start, -count * 2 + maxLines);
+        index = 0;
+        for (int i = 0; i < listing.size(); i++) {
+            if (listing.at(i).offset >= topOffset) {
+                index = qMax(0, i + count);
+                break;
+            }
+        }
+    }
+
+    RVA offset = RVA_INVALID;
+    if (!listing.isEmpty()) {
+        index = qBound(0, index, listing.size() - 1);
+        // The listing always starts at the first line of an address, so snap to
+        // it instead of scrolling into the middle of a group of lines.
+        while (index > 0 && listing.at(index - 1).offset == listing.at(index).offset) {
+            index--;
+        }
+        offset = listing.at(index).offset;
+    }
+    if (offset == RVA_INVALID || offset == topOffset) {
+        // Nothing usable to jump to, step a single instruction so that a long
+        // run of lines sharing one address can never block the scroll.
+        offset = (count > 0) ? Core()->nextOpAddr(topOffset, 1) : Core()->prevOpAddr(topOffset, 1);
+    }
+
     // Require strict progress in the requested direction; otherwise stay put
     // instead of teleporting to 0/RVA_MAX as the old guard did.
     if ((count > 0 && offset <= topOffset) || (count < 0 && offset >= topOffset)) {
         return;
     }
     refreshDisasm(offset);
+}
+
+/**
+ * @brief Turn a wheel event into a line scroll, shared by the listing and the
+ * arrows panel so that both scroll by the same amount.
+ */
+void DisassemblyWidget::wheelScroll(QWheelEvent *event)
+{
+    const qreal notches = event->angleDelta().y() / 120.0;
+    if (notches * wheelRemainder < 0) { // direction changed, drop the leftover
+        wheelRemainder = 0;
+    }
+    wheelRemainder += notches * QApplication::wheelScrollLines();
+    const int count = int(wheelRemainder);
+    wheelRemainder -= count;
+    // Never scroll more than a screenful at once, no matter how the system
+    // wheel settings are configured.
+    const int limit = qMax(1, maxLines);
+    scrollLines(-qBound(-limit, count, limit));
 }
 
 bool DisassemblyWidget::updateMaxLines()
@@ -1010,9 +1050,9 @@ void DisassemblyWidget::moveCursorRelative(bool up, bool page)
         int blockNumber = mDisasTextEdit->textCursor().blockNumber();
 
         if (blockNumber == blockCount - 1 && !up) {
-            scrollInstructions(1);
+            scrollLines(1);
         } else if (blockNumber == 0 && up) {
-            scrollInstructions(-1);
+            scrollLines(-1);
         }
 
         mDisasTextEdit->moveCursor(up ? QTextCursor::Up : QTextCursor::Down);
@@ -1275,33 +1315,6 @@ void DisassemblyWidget::setupColors()
             .arg(ConfigColor("btext").name()));
 }
 
-DisassemblyScrollArea::DisassemblyScrollArea(QWidget *parent)
-    : QAbstractScrollArea(parent)
-{}
-
-bool DisassemblyScrollArea::viewportEvent(QEvent *event)
-{
-    int dy = verticalScrollBar()->value() - 5;
-    if (dy != 0) {
-        emit scrollLines(dy);
-    }
-
-    if (event->type() == QEvent::Resize) {
-        emit disassemblyResized();
-    }
-
-    resetScrollBars();
-    return QAbstractScrollArea::viewportEvent(event);
-}
-
-void DisassemblyScrollArea::resetScrollBars()
-{
-    verticalScrollBar()->blockSignals(true);
-    verticalScrollBar()->setRange(0, 10);
-    verticalScrollBar()->setValue(5);
-    verticalScrollBar()->blockSignals(false);
-}
-
 qreal DisassemblyTextEdit::textOffset() const
 {
     return (blockBoundingGeometry(document()->begin()).topLeft() + contentOffset()).y();
@@ -1321,16 +1334,18 @@ bool DisassemblyTextEdit::viewportEvent(QEvent *event)
             emit refreshContents();
             event->accept();
             return true;
-        } else {
-            // just scroll the disasm
-            emit refreshContents();
-            event->accept();
-            return false;
         }
+        if (qAbs(wheelEvent->angleDelta().x()) > qAbs(wheelEvent->angleDelta().y())) {
+            break; // let QPlainTextEdit scroll horizontally
+        }
+        disas->wheelScroll(wheelEvent);
+        event->accept();
+        return true;
     }
     default:
-        return QAbstractScrollArea::viewportEvent(event);
+        break;
     }
+    return QAbstractScrollArea::viewportEvent(event);
 }
 
 void DisassemblyTextEdit::scrollContentsBy(int dx, int dy)
@@ -1436,10 +1451,7 @@ DisassemblyLeftPanel::DisassemblyLeftPanel(DisassemblyWidget *disas)
 
 void DisassemblyLeftPanel::wheelEvent(QWheelEvent *event)
 {
-    int count = -(event->angleDelta() / 15).y();
-    count -= (count > 0 ? 5 : -5);
-
-    this->disas->scrollInstructions(count);
+    this->disas->wheelScroll(event);
 }
 
 void DisassemblyLeftPanel::paintEvent(QPaintEvent *event)

--- a/src/widgets/DisassemblyWidget.h
+++ b/src/widgets/DisassemblyWidget.h
@@ -16,9 +16,9 @@
 #include <QTextEdit>
 
 class DisassemblyTextEdit;
-class DisassemblyScrollArea;
 class DisassemblyContextMenu;
 class DisassemblyLeftPanel;
+class QWheelEvent;
 
 class DisassemblyWidget : public MemoryDockWidget
 {
@@ -50,7 +50,8 @@ public slots:
     void copyBytes();
     void fontsUpdatedSlot();
     void colorsUpdatedSlot();
-    void scrollInstructions(int count);
+    void scrollLines(int count);
+    void wheelScroll(QWheelEvent *event);
     void seekPrev();
     void setPreviewMode(bool previewMode);
     QFontMetrics getFontMetrics();
@@ -69,7 +70,6 @@ protected slots:
 
 protected:
     DisassemblyContextMenu *mCtxMenu;
-    DisassemblyScrollArea *mDisasScrollArea;
     DisassemblyTextEdit *mDisasTextEdit;
     DisassemblyLeftPanel *leftPanel;
     QList<DisassemblyLine> lines;
@@ -79,6 +79,9 @@ private:
     RVA topOffset;
     RVA bottomOffset;
     int maxLines;
+    /// Leftover of the last wheel event, so hi-res wheels and touchpads
+    /// accumulate their sub-notch deltas instead of dropping them.
+    qreal wheelRemainder;
 
     QString curHighlightedWord;
 
@@ -132,24 +135,6 @@ private:
     bool isActionableTokenAt(const QPoint &pos);
     void updateDisassemblyCursor(const QPoint &pos, Qt::MouseButtons buttons);
     QString deepLinkAt(const QPoint &pos);
-};
-
-class DisassemblyScrollArea : public QAbstractScrollArea
-{
-    Q_OBJECT
-
-public:
-    explicit DisassemblyScrollArea(QWidget *parent = nullptr);
-
-signals:
-    void scrollLines(int lines);
-    void disassemblyResized();
-
-protected:
-    bool viewportEvent(QEvent *event) override;
-
-private:
-    void resetScrollBars();
 };
 
 class DisassemblyTextEdit : public QPlainTextEdit


### PR DESCRIPTION
Fixes #311 — scrolling up moved the listing by a different amount of lines than scrolling down.

## Root cause

The wheel moved the top address by N **instructions** (`nextOpAddr`/`prevOpAddr`), but the view is drawn with `pdJ`, which renders one entry per **line**: comments, xrefs, labels, function headers and separators all take extra lines. So a notch that steps 3 instructions scrolls 3 + however many pseudo-lines those instructions carry — and the pseudo-lines leaving the top when scrolling down are not the ones entering it when scrolling up.

Three widgets also disagreed about how much a notch is worth:

* The listing scrolled through `DisassemblyScrollArea`, a hidden `0..10` scrollbar whose `value - 5` was sampled one event *late*, silently capping any system wheel setting at 5 lines.
* The arrows panel used `-(angleDelta/15).y()` minus a hardcoded 5, i.e. 3 lines per notch — and it **inverts** on hi-res wheels and touchpads that send sub-notch deltas (delta 40 → `-3 + 5` = +2, scrolls the wrong way).
* The event only ever reached the scroll area because the text edit's own scrollbar got snapped back to 0 before `QAbstractSlider` accepted it.

Not platform specific, but easiest to observe on Windows/X11 where a notch is a discrete 120 units; a touchpad's fine-grained deltas hide it.

## Changes

* One wheel handler, `DisassemblyWidget::wheelScroll()`, shared by the listing and the arrows panel, accumulating sub-notch deltas so hi-res wheels and touchpads scroll smoothly and in the right direction. Honors `QApplication::wheelScrollLines()`, clamped to one screenful.
* `scrollInstructions()` becomes `scrollLines()`: going down takes the address of the line N rows away from the already cached `lines` listing; going up disassembles backwards from `prevOpAddr()` and picks the line N rows above the current top. Both snap to the first line of an address so the view never starts mid-comment, with a single-instruction fallback so a long run of lines sharing one address can never block the scroll.
* `DisassemblyScrollArea` is deleted. Its resize signal was already covered by the existing event filter on the text edit viewport, and the text edit now sits directly in the splitter.
* Arrow keys at the top/bottom edge scroll one line instead of one instruction, matching where the cursor actually moves.

Net -3 lines, and most of the additions are comments.

## Testing

* Builds clean with Qt 6.4 + r2 6.2.1, no new warnings; starts and runs on an offscreen platform plugin.
* The scroll math was simulated against real `pdJ`/`pdj`/`/O` output on `/bin/ls`: every step moves **exactly** the requested number of lines up and down (1, 3 and 5 line steps), and the new listing's head matches the old listing's tail at that index, so the view shifts rather than jumps. The only deviation is by design: at a 4-line function header, scrolling 3 lines down moves 4, because the listing can only start at an address.

Not verified: an interactive session with a real mouse on Windows — no display in this environment.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JJ72FFkQ3XejWCEEh6qTEn)_